### PR TITLE
feat: add context window command and breakdown rendering

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercode-cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "AI-powered coding agent CLI",
   "main": "dist/main.js",
   "bin": {

--- a/apps/supercode-cli/server/src/cli/ai/chat/chat.ts
+++ b/apps/supercode-cli/server/src/cli/ai/chat/chat.ts
@@ -37,6 +37,7 @@ import { buildSystemPrompt } from "src/cli/workspace/context.ts"
 import { tools } from "src/tools/registry.ts"
 import { renderWorkspaceBanner } from "src/cli/workspace/format.ts"
 import { handleSlashCommand, isSlashCommand } from "src/cli/commands/slashCommands/index.ts"
+import { renderContextBreakdown } from "src/cli/commands/slashCommands/context-window.ts"
 import { saveCliConfig } from "src/lib/cli-config"
 
 async function getUserFromToken() {
@@ -200,11 +201,12 @@ let stdinPrevWrapLines = 1
 const SLASH_COMMANDS = [
   { cmd: "/model", desc: "Switch AI provider or model" },
   { cmd: "/connect", desc: "Connect API key for direct access" },
+  { cmd: "/context", desc: "Show context window usage and breakdown" },
   { cmd: "/help", desc: "Show available commands and models" },
   { cmd: "/exit", desc: "End the session" },
 ]
 
-const SLASH_LIST_HEIGHT = 2 + 4 + 2 // dividers + header + 4 commands + bottom divider
+const SLASH_LIST_HEIGHT = 2 + 5 + 2 // dividers + header + 5 commands + bottom divider
 
 let slashListLines = 0
 let slashSelected = -1
@@ -559,6 +561,9 @@ export async function chatLoop(
   let sessionTokens = 0
   let provider = initialProvider
   let contextWindow = getContextWindow(provider.modelName)
+  let sessionStartTime = Date.now()
+  let lastUsage: { promptTokens?: number; completionTokens?: number; totalTokens?: number } | undefined = undefined
+  let lastElapsed: number | undefined = undefined
 
   while (true) {
     try {
@@ -615,6 +620,18 @@ export async function chatLoop(
             }
           }
           process.stdout.write(`\r\n`)
+        } else if (result?.type === "context") {
+          renderContextBreakdown({
+            modelName: provider.modelName,
+            contextWindow,
+            sessionTokens,
+            messageCount,
+            lastUsage,
+            lastElapsed,
+            sessionStartTime,
+            mode: conversation.mode,
+          })
+          process.stdout.write(`\r\n`)
         } else if (result?.type === "unknown") {
           process.stdout.write(`\r\n ${chalk.hex(theme.red)("◆")} unknown slash command: ${trimmed.split(" ")[0]}\r\n\n`)
         } else {
@@ -645,6 +662,9 @@ export async function chatLoop(
 
         const responseTokens = result.usage?.totalTokens ?? 0
         sessionTokens += responseTokens
+
+        lastUsage = result.usage
+        lastElapsed = result.elapsed
 
         try {
           chatStatusBar({

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/context-window.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/context-window.ts
@@ -1,0 +1,240 @@
+import chalk from "chalk"
+import { theme, formatTokenCount, heavyDivider } from "src/cli/utils/tui.ts"
+
+
+
+export interface ContextState{
+    modelName: string
+    contextWindow: number
+    sessionTokens: number
+    messageCount: number
+    lastUsage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number }
+    lastElapsed?: number
+    sessionStartTime: number
+    mode: string
+}
+
+// elapsedStr(start) → "2m 34s"
+//
+// Converts a starting timestamp into a human-readable elapsed duration.
+// Falls through hr→min→sec so short sessions show "5s" and long ones
+// show "1h 12m 3s" without awkward zero values.
+//
+// Why hand-roll instead of using a library?
+//   - The CLI already avoids date libs (zero dep overhead)
+//   - This is a ~10-line function with a single caller
+//   - Node's Date API + integer math is sufficient here
+//
+function elapsedStr(start: number): string {
+    // Total milliseconds since start
+    const ms = Date.now() - start
+    // Floor-divide down through seconds → minutes → hours
+    const secs = Math.floor(ms / 1000)
+    const mins = Math.floor(secs / 60)
+    const hrs = Math.floor(mins / 60)
+  
+    // Only include units with non-zero values, dropping granularity
+    // as duration increases (hours don't show seconds, minutes don't show ms)
+    if (hrs > 0) return `${hrs}h ${mins % 60}m ${secs % 60}s`
+    if (mins > 0) return `${mins}m ${secs % 60}s`
+    return `${secs}s`
+  }
+  
+  // progressBar(pct, width) → "████░░░░  33%"
+//
+// Draws a visual bar using block characters: █ (filled) and ░ (empty).
+// The ratio of filled:empty is proportional to pct of `width` columns.
+//
+// Why block chars instead of a spinner / partial chars?
+//   - █ and ░ are monospace and align perfectly in terminals
+//   - They're supported in every modern terminal (no Unicode issues)
+//   - The phosphor-green theme uses color to reinforce the ratio
+//
+function progressBar(pct: number, width: number): string {
+    // Number of filled cells (rounded, so at small widths the bar is approximate)
+    const filled = Math.round((pct / 100) * width)
+    // Remaining cells (clamped to 0 in case pct rounds to > 100)
+    const empty = width - filled
+  
+    // Green filled blocks for the "used" portion
+    const fill = chalk.hex(theme.green)("█".repeat(filled))
+    // Dim green dots for the "available" portion
+    const rest = chalk.hex(theme.greenDim)("░".repeat(Math.max(0, empty)))
+  
+    return fill + rest
+  }
+  
+  // ──────── STYLING SHORTHANDS ────────
+//
+// These are small wrapper functions that save typing and ensure consistent
+// styling across every line in the breakdown. Each wraps chalk with a
+// specific theme color and a fixed label width (18 chars).
+//
+// - label: left-column titles (right-padded to 18 for alignment)
+// - value: right-column data values (plain text color)
+// - dim:  secondary/annotation text like "tokens" and separators
+// - amber: numbers that deserve attention (token counts, percentages)
+//
+// Why 18 chars? It's the longest label ("Max Context"/"Output Tokens")
+// + 2 chars padding, so all values start at column 21.
+//
+const label = (s: string) => chalk.hex(theme.greenGlow)(s.padEnd(18))
+const value = (s: string) => chalk.hex(theme.text)(s)
+const dim = (s: string) => chalk.hex(theme.greenDim)(s)
+const amber = (s: string) => chalk.hex(theme.amber)(s)
+
+
+// ──────── MAIN RENDERER ────────
+
+// renderContextBreakdown(state)
+//
+// The single public entry point. Accepts a ContextState snapshot and writes
+// the formatted breakdown directly to stdout.
+//
+// Why write to stdout directly instead of returning a string?
+//   - The existing TUI utilities (frame, sectionHeader, heavyDivider) all
+//     write to stdout — consistency
+//   - The chat loop expects side effects for slash command rendering
+//     (see /help which also calls renderHelp() → stdout)
+//   - Building a string then writing once is still fine; we assemble it
+//     in `lines[]` and write it in one shot at the end
+//
+export function renderContextBreakdown(state: ContextState) {
+    // ── Terminal width detection ──
+    //
+    // process.stdout.columns gives the current terminal width.
+    // ?? 80 is a safe fallback for non-TTY environments (piped output, tests).
+    //
+    const w = process.stdout.columns ?? 80
+  
+    // innerW: usable width minus the box frame border (3 chars left + 3 right)
+    // Math.max(40, ...) prevents absurdly narrow boxes on tiny terminals.
+    const innerW = Math.max(40, w - 6)
+  
+    // ── Compute derived values ──
+    //
+    // pct: what fraction of the context window has been used (0–100).
+    //   - Divided by contextWindow (could be 1M+), then rounded.
+    //   - Clamped at 100% in case sessionTokens exceeds window (edge case).
+    //
+    const pct = state.contextWindow > 0
+      ? Math.min(100, Math.round((state.sessionTokens / state.contextWindow) * 100))
+      : 0
+  
+    // available: tokens remaining in the context window.
+    //   - Math.max(0, ...) prevents negative values.
+    //
+    const available = Math.max(0, state.contextWindow - state.sessionTokens)
+  
+    // ── Build content lines ──
+    //
+    // We push formatted strings into an array, then join them at the end.
+    // This lets us conditionally add sections (like the "Last Response" block
+    // which only appears if lastUsage is defined).
+    //
+    const lines: string[] = []
+  
+    // Blank line for top padding inside the box
+    lines.push("")
+  
+    // ── Model & Context rows ──
+    //
+    // Each row: label (18 chars) + value + optional annotation.
+    // The label/value helpers apply consistent colors from the helper fns above.
+    //
+    // Line 1: Model name
+    lines.push(`  ${label("Model")}     ${value(state.modelName)}`)
+    // Line 2: Max context (formatted like "128K" or "1M")
+    lines.push(`  ${label("Max Context")}  ${value(formatTokenCount(state.contextWindow))} ${dim("tokens")}`)
+    // Line 3: Used tokens + percentage (amber for attention)
+    lines.push(`  ${label("Used")}       ${amber(formatTokenCount(state.sessionTokens))} ${dim("tokens")}  ${amber(`(${pct}%)`)}`)
+    // Line 4: Available tokens + percentage (dim, less important)
+    lines.push(`  ${label("Available")}  ${value(formatTokenCount(available))} ${dim("tokens")}  ${dim(`(${100 - pct}%)`)}`)
+  
+    lines.push("")
+  
+    // ── Section separator ──
+    //
+    // A full-width dim line to visually separate sections within the box.
+    // Using repeat(innerW) so it spans the full content width.
+    //
+    lines.push(`  ${dim("━".repeat(innerW))}`)
+    lines.push("")
+  
+    // ── Session section ──
+    //
+    lines.push(`  ${label("Messages")}    ${value(String(state.messageCount))}`)
+    lines.push(`  ${label("Mode")}        ${value(state.mode)}`)
+    // elapsedStr computes the wall-clock duration of the entire session
+    lines.push(`  ${label("Session")}     ${value(elapsedStr(state.sessionStartTime))}`)
+    lines.push("")
+  
+    // ── Last Response section (conditional) ──
+    //
+    // Only shown if there has been at least one AI response (lastUsage is defined).
+    // This section is hidden on brand-new sessions, keeping the output clean.
+    //
+    if (state.lastUsage) {
+      lines.push(`  ${dim("━".repeat(innerW))}`)
+      lines.push("")
+  
+      // totalTokens might come directly from the provider, or we compute it
+      // as prompt + completion. The ?? chain handles both cases.
+      const total = state.lastUsage.totalTokens ??
+        (state.lastUsage.promptTokens ?? 0) + (state.lastUsage.completionTokens ?? 0)
+  
+      lines.push(`  ${label("Input Tokens")}  ${value(formatTokenCount(state.lastUsage.promptTokens ?? 0))}`)
+      lines.push(`  ${label("Output Tokens")} ${value(formatTokenCount(state.lastUsage.completionTokens ?? 0))}`)
+      lines.push(`  ${label("Total")}       ${amber(formatTokenCount(total))}`)
+  
+      // Elapsed time for the last response: fast responses show ms, slower ones show seconds
+      if (state.lastElapsed !== undefined) {
+        const time = state.lastElapsed < 1000
+          ? `${state.lastElapsed}ms`
+          : `${(state.lastElapsed / 1000).toFixed(1)}s`
+        lines.push(`  ${label("Latency")}     ${value(time)}`)
+      }
+      lines.push("")
+    }
+  
+    // ── Visual progress bar section ──
+    //
+    // The bar width is capped at 40 chars so it doesn't stretch across the
+    // entire terminal on wide screens. The percentage label sits to the right.
+    //
+    lines.push(`  ${dim("━".repeat(innerW))}`)
+    lines.push("")
+    const barWidth = Math.min(40, innerW - 8)
+    lines.push(`  ${progressBar(pct, barWidth)}  ${amber(`${pct}%`)}`)
+    lines.push("")
+  
+    // ── Build the outer box ──
+    //
+    // The box uses Unicode box-drawing characters (┏ ┓ ┛ ━) to create a
+    // framed panel. This matches the existing TUI aesthetic (see frame(),
+    // sectionHeader() in tui.ts).
+    //
+    // Top border: "┏━━ Context Window ━━<fill>┓"
+    //   - Fixed title in the center-left, then dim fill to the right edge
+    //
+    const content = lines.join("\n")
+  
+    // Construct the title section of the top border
+    const title = `${dim("┏━━")} ${chalk.hex(theme.green).bold("Context Window")} ${dim("━━")}`
+    const titlePart = chalk.hex(theme.green)(`${title}`)
+    const titleVisible = title.length
+    const topFill = Math.max(0, w - titleVisible - 1)
+  
+    // top: full top border line
+    const top = chalk.hex(theme.green)(titlePart) + chalk.hex(theme.greenDim)("━".repeat(topFill)) + chalk.hex(theme.green)("┓")
+  
+    // bottom: full bottom border line (just fill + corner)
+    const bottom = chalk.hex(theme.greenDim)("━".repeat(w - 2)) + chalk.hex(theme.green)("┛")
+  
+    // ── Write to stdout ──
+    //
+    // Single write call (one I/O operation) for the entire box.
+    // \r\n ensures correct behavior on both Unix and Windows terminals.
+    //
+    process.stdout.write(`\r\n${top}\r\n${content}\r\n${bottom}\r\n`)
+  }

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/index.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/index.ts
@@ -7,7 +7,7 @@ import { theme, heavyDivider } from "src/cli/utils/tui.ts"
 import type { ModelProvider } from "src/cli/ai/provider.ts"
 
 export interface SlashCommandResult {
-  type: "model_change" | "help" | "unknown" | "exit" | "connect"
+  type: "model_change" | "help" | "unknown" | "exit" | "connect" | "context"
   provider?: ModelProvider
   model?: string
   label?: string
@@ -16,6 +16,7 @@ export interface SlashCommandResult {
 const COMMANDS = [
   { cmd: "/model", desc: "Switch AI provider or model" },
   { cmd: "/connect", desc: "Connect API key for direct access" },
+  { cmd: "/context", desc: "Show context window usage and breakdown" },
   { cmd: "/help", desc: "Show available commands and models" },
   { cmd: "/exit", desc: "End the session" },
 ]
@@ -36,6 +37,9 @@ const handlers: Record<string, (args: string) => Promise<SlashCommandResult>> = 
   help: async () => {
     renderHelp()
     return { type: "help" }
+  },
+  context: async () => {
+    return { type: "context" }
   },
 }
 

--- a/apps/web/app/(pages)/compare/page.tsx
+++ b/apps/web/app/(pages)/compare/page.tsx
@@ -21,25 +21,25 @@ const tools = [
     badgeColor: "text-emerald-400",
   },
   {
+    name: "CommandCode",
+    tagline: "taste-learning agent",
+    href: "https://commandcode.ai",
+    badge: "PRO",
+    badgeColor: "text-orange-400",
+  },
+  {
+    name: "FreeBuff",
+    tagline: "free ad-supported agent",
+    href: "https://freebuff.com",
+    badge: "FREE",
+    badgeColor: "text-sky-400",
+  },
+  {
     name: "Claude Code",
     tagline: "agentic coding by Anthropic",
     href: "https://docs.anthropic.com/en/docs/claude-code/overview",
     badge: "PRO",
     badgeColor: "text-orange-400",
-  },
-  {
-    name: "Hermes Agent",
-    tagline: "autonomous AI agent",
-    href: "https://github.com/NousResearch/hermes-agent",
-    badge: "OSS",
-    badgeColor: "text-violet-400",
-  },
-  {
-    name: "Warp",
-    tagline: "AI-native terminal",
-    href: "https://www.warp.dev",
-    badge: "GUI",
-    badgeColor: "text-sky-400",
   },
   {
     name: "Cursor",
@@ -55,9 +55,9 @@ interface FeatureRow {
   name: string
   supercode: boolean
   opencode: boolean
+  commandcode: boolean
+  freebuff: boolean
   claude: boolean
-  hermes: boolean
-  warp: boolean
   cursor: boolean
 }
 
@@ -70,21 +70,31 @@ type Row = CategoryDivider | FeatureRow
 
 const rows: Row[] = [
   { type: "divider", label: "Core" },
-  { type: "feature", name: "Terminal-native", supercode: true, opencode: true, claude: true, hermes: false, warp: true, cursor: false },
-  { type: "feature", name: "Open source", supercode: true, opencode: true, claude: false, hermes: true, warp: false, cursor: false },
+  { type: "feature", name: "Terminal-native", supercode: true, opencode: true, commandcode: true, freebuff: true, claude: true, cursor: false },
+  { type: "feature", name: "Open source", supercode: true, opencode: true, commandcode: false, freebuff: true, claude: false, cursor: false },
+  { type: "divider", label: "Pricing" },
+  { type: "feature", name: "Free to start ($0)", supercode: true, opencode: true, commandcode: false, freebuff: true, claude: false, cursor: true },
+  { type: "feature", name: "Free BYOK", supercode: true, opencode: true, commandcode: false, freebuff: false, claude: false, cursor: false },
+  { type: "feature", name: "Free open models", supercode: true, opencode: true, commandcode: true, freebuff: true, claude: false, cursor: true },
   { type: "divider", label: "Access & Control" },
-  { type: "feature", name: "Full machine access", supercode: true, opencode: false, claude: false, hermes: true, warp: false, cursor: false },
-  { type: "feature", name: "Granular permissions", supercode: true, opencode: false, claude: false, hermes: false, warp: false, cursor: false },
+  { type: "feature", name: "Full machine access", supercode: true, opencode: false, commandcode: true, freebuff: true, claude: true, cursor: false },
+  { type: "feature", name: "Granular permissions", supercode: true, opencode: false, commandcode: false, freebuff: false, claude: false, cursor: false },
   { type: "divider", label: "Models & Data" },
-  { type: "feature", name: "Free models included", supercode: true, opencode: false, claude: false, hermes: false, warp: false, cursor: true },
-  { type: "feature", name: "BYO API key", supercode: true, opencode: true, claude: false, hermes: false, warp: false, cursor: true },
-  { type: "feature", name: "Multi-model support", supercode: true, opencode: false, claude: false, hermes: false, warp: false, cursor: true },
-  { type: "feature", name: "Persistent memory", supercode: true, opencode: false, claude: false, hermes: false, warp: false, cursor: false },
+  { type: "feature", name: "Multi-model support", supercode: true, opencode: true, commandcode: true, freebuff: true, claude: false, cursor: true },
+  { type: "feature", name: "Persistent memory", supercode: true, opencode: true, commandcode: true, freebuff: false, claude: true, cursor: true },
+  { type: "feature", name: "Local model support", supercode: false, opencode: true, commandcode: false, freebuff: false, claude: false, cursor: false },
   { type: "divider", label: "Capabilities" },
-  { type: "feature", name: "File editing", supercode: true, opencode: true, claude: true, hermes: true, warp: false, cursor: true },
-  { type: "feature", name: "Web search", supercode: true, opencode: false, claude: false, hermes: true, warp: false, cursor: false },
-  { type: "feature", name: "Voice control", supercode: true, opencode: false, claude: false, hermes: false, warp: false, cursor: false },
-  { type: "feature", name: "Session history", supercode: true, opencode: true, claude: true, hermes: false, warp: true, cursor: true },
+  { type: "feature", name: "Web search", supercode: true, opencode: true, commandcode: true, freebuff: true, claude: true, cursor: false },
+  { type: "feature", name: "Voice control", supercode: true, opencode: false, commandcode: false, freebuff: false, claude: false, cursor: false },
+  { type: "feature", name: "PR review", supercode: false, opencode: false, commandcode: true, freebuff: true, claude: true, cursor: false },
+]
+
+const pricingRows = [
+  { feature: "Entry price", supercode: "$0", opencode: "$0 BYOK", commandcode: "$1/mo Go", freebuff: "$0 (ads)", claude: "$20/mo Pro", cursor: "$0 Hobby" },
+  { feature: "Free open models", supercode: "Included", opencode: "Limited", commandcode: "On Go plan", freebuff: "Always free", claude: "—", cursor: "Limited" },
+  { feature: "Premium models", supercode: "BYOK (any)", opencode: "$10/mo Go or BYOK", commandcode: "$15/mo+ Pro", freebuff: "Pro $100–500", claude: "Included", cursor: "$20/mo Pro" },
+  { feature: "Team pricing", supercode: "$0 (BYOK)", opencode: "—", commandcode: "$40/seat", freebuff: "$100–500/seat", claude: "$100–200/mo", cursor: "$40/seat" },
+  { feature: "Free in India?", supercode: "✓", opencode: "✓", commandcode: "✓", freebuff: "✗", claude: "✓", cursor: "✓" },
 ]
 
 function CheckMark() {
@@ -92,30 +102,30 @@ function CheckMark() {
 }
 
 function CrossMark() {
-  return <span className="text-muted-foreground/25 text-[18px] leading-none font-mono">—</span>
+  return <span className="text-muted-foreground/40 text-[18px] leading-none font-mono">—</span>
 }
 
 function FeatureCell({ value }: { value: boolean }) {
   return (
-    <td className="py-4 text-center border-b border-border/30">
+    <td className="py-4 text-center border-b border-border/40">
       {value ? <CheckMark /> : <CrossMark />}
     </td>
   )
 }
 
-function ScoreBar({ value, label }: { value: number; label: string }) {
+function ScoreBar({ value, label, index }: { value: number; label: string; index: number }) {
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <span className="text-[13px] font-mono text-foreground/70">{label}</span>
-        <span className="text-[13px] font-mono text-muted-foreground">{value}/12</span>
+        <span className="text-[13px] font-mono text-foreground/60">{value}/13</span>
       </div>
       <div className="h-[6px] bg-border/20 rounded-full overflow-hidden">
         <motion.div
           initial={{ width: 0 }}
-          whileInView={{ width: `${(value / 12) * 100}%` }}
+          whileInView={{ width: `${(value / 13) * 100}%` }}
           viewport={{ once: true }}
-          transition={{ duration: 1, ease: "easeOut", delay: 0.3 }}
+          transition={{ duration: 0.8, ease: [0.23, 1, 0.32, 1], delay: 0.15 + index * 0.08 }}
           className="h-full bg-gradient-to-r from-primary/60 to-primary rounded-full"
         />
       </div>
@@ -124,12 +134,12 @@ function ScoreBar({ value, label }: { value: number; label: string }) {
 }
 
 const scores = [
-  { label: "Supercode", value: 12 },
-  { label: "OpenCode", value: 5 },
-  { label: "Claude Code", value: 3 },
-  { label: "Hermes Agent", value: 5 },
-  { label: "Warp", value: 3 },
-  { label: "Cursor", value: 6 },
+  { label: "Supercode", value: 11 },
+  { label: "OpenCode", value: 9 },
+  { label: "FreeBuff", value: 8 },
+  { label: "CommandCode", value: 7 },
+  { label: "Claude Code", value: 5 },
+  { label: "Cursor", value: 5 },
 ]
 
 function StatCard({
@@ -148,15 +158,23 @@ function StatCard({
       initial={{ opacity: 0, y: 24 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      transition={{ delay: index * 0.1, duration: 0.5 }}
-      className="border border-border/30 rounded-xl p-6 bg-card/30 backdrop-blur-sm"
+      transition={{ delay: index * 0.08, duration: 0.5, ease: [0.23, 1, 0.32, 1] }}
+      className="border border-border/40 rounded-xl p-6 bg-card/50 backdrop-blur-sm hover:-translate-y-1 hover:shadow-lg transition-all duration-200 ease-out"
     >
       <div className="text-[28px] mb-2 font-mono">{icon}</div>
       <div className="text-[28px] font-semibold tracking-tight text-foreground font-mono">
         {value}
       </div>
-      <div className="text-[13px] text-muted-foreground font-mono mt-1">{label}</div>
+      <div className="text-[13px] text-foreground/70 font-mono mt-1">{label}</div>
     </motion.div>
+  )
+}
+
+function PricingCell({ value, highlight }: { value: string; highlight?: boolean }) {
+  return (
+    <td className={`py-4 px-3 text-center border-b border-border/40 text-[13px] font-mono leading-relaxed ${highlight ? "text-primary" : "text-foreground/85"}`}>
+      {value}
+    </td>
   )
 }
 
@@ -174,10 +192,10 @@ export default function ComparePage() {
           <motion.div
             initial={{ opacity: 0, y: 32 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
+            transition={{ duration: 0.6, ease: [0.23, 1, 0.32, 1] }}
           >
-            <span className="inline-block text-[12px] font-mono uppercase tracking-[0.25em] text-muted-foreground/50 mb-6">
-              — Supercode v0.1.7
+            <span className="inline-block text-[12px] font-mono uppercase tracking-[0.25em] text-primary mb-6">
+              $ Supercode v0.1.14
             </span>
             <h1 className="text-[48px] md:text-[72px] font-semibold tracking-tight leading-[1.05] mb-6">
               <span className="inline-flex items-baseline gap-1">
@@ -189,9 +207,9 @@ export default function ComparePage() {
               <br />
               vs the rest
             </h1>
-            <p className="text-[17px] text-muted-foreground font-mono max-w-[600px] leading-relaxed">
+            <p className="text-[17px] text-foreground/70 font-mono max-w-[600px] leading-relaxed">
               An honest comparison. Supercode is the only terminal AI agent that gives you full machine
-              control with granular permissions — no vendor lock-in, no black boxes.
+              control with granular permissions and zero vendor lock-in — free, open source, always.
             </p>
           </motion.div>
         </div>
@@ -201,27 +219,109 @@ export default function ComparePage() {
       <section className="px-6 pb-20">
         <div className="max-w-[1100px] mx-auto">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <StatCard icon="⊞" value="12/12" label="features covered" index={0} />
+            <StatCard icon="⊞" value="11/13" label="features covered" index={0} />
             <StatCard icon="⚡" value="100%" label="open source" index={1} />
             <StatCard icon="⊡" value="5+" label="models supported" index={2} />
-            <StatCard icon="◈" value="0" label="vendor lock-in" index={3} />
+            <StatCard icon="◈" value="$0" label="to get started" index={3} />
           </div>
         </div>
       </section>
 
-      {/* Comparison table */}
+      {/* Pricing comparison */}
       <section className="px-6 pb-24">
         <div className="max-w-[1100px] mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
+            transition={{ duration: 0.4, ease: [0.23, 1, 0.32, 1] }}
             className="mb-8"
           >
-            <h2 className="text-[13px] font-mono uppercase tracking-[0.2em] text-muted-foreground/50 mb-1">
+            <h2 className="text-[13px] font-mono uppercase tracking-[0.2em] text-primary mb-1">
+              Pricing comparison
+            </h2>
+            <p className="text-[14px] text-foreground/70 font-mono">
+              What it actually costs to use each tool.
+            </p>
+          </motion.div>
+
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[700px]">
+              <thead>
+                <tr>
+                  <th className="text-left pb-5 pr-6 w-[180px]">
+                    <span className="text-[11px] font-mono uppercase tracking-[0.15em] text-foreground/70">
+                      &nbsp;
+                    </span>
+                  </th>
+                  {tools.map((tool) => (
+                    <th key={tool.name} className="pb-5 text-center px-3">
+                      <div className="flex flex-col items-center gap-1">
+                        <a
+                          href={tool.href}
+                          target={tool.href.startsWith("http") ? "_blank" : undefined}
+                          rel={tool.href.startsWith("http") ? "noopener noreferrer" : undefined}
+                          className={`text-[13px] font-mono font-medium transition-colors ${
+                            tool.name === "Supercode"
+                              ? "text-primary"
+                              : "text-foreground/85 hover:text-foreground"
+                          }`}
+                        >
+                          {tool.name}
+                        </a>
+                        <span
+                          className={`text-[9px] font-mono uppercase tracking-[0.1em] ${tool.badgeColor} opacity-80`}
+                        >
+                          {tool.badge}
+                        </span>
+                      </div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {pricingRows.map((row, i) => (
+                  <motion.tr
+                    key={row.feature}
+                    initial={{ opacity: 0, y: 12 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ delay: i * 0.04, duration: 0.35, ease: [0.23, 1, 0.32, 1] }}
+                    className="group"
+                  >
+                    <td className="py-4 pr-6 border-b border-border/40">
+                      <span className="text-[14px] font-mono text-foreground/85 group-hover:text-foreground transition-colors">
+                        {row.feature}
+                      </span>
+                    </td>
+                    <PricingCell value={row.supercode} highlight />
+                    <PricingCell value={row.opencode} />
+                    <PricingCell value={row.commandcode} />
+                    <PricingCell value={row.freebuff} />
+                    <PricingCell value={row.claude} />
+                    <PricingCell value={row.cursor} />
+                  </motion.tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* Feature comparison */}
+      <section className="px-6 pb-24">
+        <div className="max-w-[1100px] mx-auto">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4, ease: [0.23, 1, 0.32, 1] }}
+            className="mb-8"
+          >
+            <h2 className="text-[13px] font-mono uppercase tracking-[0.2em] text-primary mb-1">
               Feature comparison
             </h2>
-            <p className="text-[14px] text-muted-foreground font-mono">
+            <p className="text-[14px] text-foreground/70 font-mono">
               Every feature that matters for a terminal AI coding agent.
             </p>
           </motion.div>
@@ -231,7 +331,7 @@ export default function ComparePage() {
               <thead>
                 <tr>
                   <th className="text-left pb-5 pr-6 w-[200px]">
-                    <span className="text-[11px] font-mono uppercase tracking-[0.15em] text-muted-foreground/40">
+                    <span className="text-[11px] font-mono uppercase tracking-[0.15em] text-white">
                       Feature
                     </span>
                   </th>
@@ -245,13 +345,13 @@ export default function ComparePage() {
                           className={`text-[13px] font-mono font-medium transition-colors ${
                             tool.name === "Supercode"
                               ? "text-primary"
-                              : "text-foreground/70 hover:text-foreground"
+                              : "text-foreground/85 hover:text-foreground"
                           }`}
                         >
                           {tool.name}
                         </a>
                         <span
-                          className={`text-[9px] font-mono uppercase tracking-[0.1em] ${tool.badgeColor} opacity-60`}
+                          className={`text-[9px] font-mono uppercase tracking-[0.1em] ${tool.badgeColor} opacity-80`}
                         >
                           {tool.badge}
                         </span>
@@ -267,10 +367,10 @@ export default function ComparePage() {
                       <tr key={row.label}>
                         <td colSpan={7} className="pt-8 pb-2">
                           <div className="flex items-center gap-3">
-                            <span className="text-[11px] font-mono uppercase tracking-[0.2em] text-muted-foreground/40">
+                            <span className="text-[11px] font-mono uppercase tracking-[0.2em] text-white">
                               {row.label}
                             </span>
-                            <div className="flex-1 h-px bg-border/20" />
+                            <div className="flex-1 h-px bg-border/30" />
                           </div>
                         </td>
                       </tr>
@@ -282,21 +382,21 @@ export default function ComparePage() {
                       initial={{ opacity: 0, y: 12 }}
                       whileInView={{ opacity: 1, y: 0 }}
                       viewport={{ once: true }}
-                      transition={{ delay: i * 0.03, duration: 0.35 }}
+                      transition={{ delay: i * 0.03, duration: 0.35, ease: [0.23, 1, 0.32, 1] }}
                       className="group"
                     >
-                      <td className="py-4 pr-6 border-b border-border/30">
-                        <span className="text-[14px] font-mono text-foreground/75 group-hover:text-foreground transition-colors">
+                      <td className="py-4 pr-6 border-b border-border/40">
+                        <span className="text-[14px] font-mono text-foreground/85 group-hover:text-foreground transition-colors">
                           {row.name}
                         </span>
                       </td>
-                      <td className="py-4 text-center border-b border-border/30 bg-primary/[0.02]">
+                      <td className="py-4 text-center border-b border-border/40 bg-primary/[0.05]">
                         <CheckMark />
                       </td>
                       <FeatureCell value={row.opencode} />
+                      <FeatureCell value={row.commandcode} />
+                      <FeatureCell value={row.freebuff} />
                       <FeatureCell value={row.claude} />
-                      <FeatureCell value={row.hermes} />
-                      <FeatureCell value={row.warp} />
                       <FeatureCell value={row.cursor} />
                     </motion.tr>
                   )
@@ -314,19 +414,20 @@ export default function ComparePage() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
+            transition={{ duration: 0.4, ease: [0.23, 1, 0.32, 1] }}
             className="mb-10"
           >
-            <h2 className="text-[13px] font-mono uppercase tracking-[0.2em] text-muted-foreground/50 mb-1">
+            <h2 className="text-[13px] font-mono uppercase tracking-[0.2em] text-foreground mb-1">
               At a glance
             </h2>
-            <p className="text-[14px] text-muted-foreground font-mono">
-              How each tool stacks up across all 12 features.
+            <p className="text-[14px] text-foreground/70 font-mono">
+              How each tool stacks up across all 13 features.
             </p>
           </motion.div>
 
           <div className="grid gap-5 max-w-[500px]">
-            {scores.map((score) => (
-              <ScoreBar key={score.label} label={score.label} value={score.value} />
+            {scores.map((score, i) => (
+              <ScoreBar key={score.label} label={score.label} value={score.value} index={i} />
             ))}
           </div>
         </div>
@@ -339,9 +440,10 @@ export default function ComparePage() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
+            transition={{ duration: 0.4, ease: [0.23, 1, 0.32, 1] }}
             className="mb-12"
           >
-            <h2 className="text-[13px] font-mono uppercase tracking-[0.2em] text-muted-foreground/50 mb-1">
+            <h2 className="text-[13px] font-mono uppercase tracking-[0.2em] text-foreground mb-1">
               The difference
             </h2>
           </motion.div>
@@ -360,8 +462,8 @@ export default function ComparePage() {
               },
               {
                 icon: "⊞",
-                title: "Zero lock-in",
-                desc: "Free models included out of the box. Or bring your own API key for Claude, GPT, Gemini — whatever you prefer. Your choice, always.",
+                title: "Zero lock-in, zero cost",
+                desc: "Free models included out of the box. Or bring your own API key for Claude, GPT, Gemini — whatever you prefer. Always free, always open.",
               },
             ].map((item, i) => (
               <motion.div
@@ -369,14 +471,14 @@ export default function ComparePage() {
                 initial={{ opacity: 0, y: 24 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
-                transition={{ delay: i * 0.1, duration: 0.5 }}
-                className="border border-border/20 rounded-xl p-7 bg-card/20"
+                transition={{ delay: i * 0.1, duration: 0.5, ease: [0.23, 1, 0.32, 1] }}
+                className="border border-border/30 rounded-xl p-7 bg-card/50"
               >
-                <div className="text-[24px] mb-4 font-mono text-primary/80">{item.icon}</div>
+                <div className="text-[24px] mb-4 font-mono text-primary">{item.icon}</div>
                 <h3 className="text-[17px] font-semibold mb-3 tracking-tight font-mono">
                   {item.title}
                 </h3>
-                <p className="text-[14px] text-muted-foreground font-mono leading-relaxed">
+                <p className="text-[14px] text-foreground/70 font-mono leading-relaxed">
                   {item.desc}
                 </p>
               </motion.div>
@@ -392,7 +494,8 @@ export default function ComparePage() {
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            className="border border-border/30 rounded-2xl p-12 md:p-16 text-center bg-card/20"
+            transition={{ duration: 0.5, ease: [0.23, 1, 0.32, 1] }}
+            className="border border-border/40 rounded-2xl p-12 md:p-16 text-center bg-card/50"
           >
             <h2 className="text-[32px] md:text-[44px] font-semibold tracking-tight mb-4 font-mono">
               Try{" "}
@@ -400,21 +503,21 @@ export default function ComparePage() {
                 Supercode
               </span>
             </h2>
-            <p className="text-[15px] text-muted-foreground font-mono max-w-[450px] mx-auto mb-8 leading-relaxed">
-              Beta launches June 22. Join the waitlist for early access.
+            <p className="text-[15px] text-foreground/70 font-mono max-w-[450px] mx-auto mb-8 leading-relaxed">
+              Free and open source. Bring your own API key or use our built-in models. No credit card needed.
             </p>
             <div className="flex items-center justify-center gap-4">
               <Link
-                href="/waitlist"
-                className="px-7 py-3 bg-primary text-primary-foreground rounded-lg text-[14px] font-medium font-mono hover:opacity-90 transition-opacity"
+                href="/login"
+                className="px-7 py-3 bg-primary text-primary-foreground rounded-lg text-[14px] font-medium font-mono hover:opacity-90 active:scale-[0.97] transition-all duration-150 ease-out"
               >
-                Join waitlist
+                Get started free
               </Link>
               <a
                 href="https://github.com/yashdev9274/superCli"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-7 py-3 border border-border rounded-lg text-[14px] font-mono text-foreground/70 hover:text-foreground transition-colors"
+                className="px-7 py-3 border border-border rounded-lg text-[14px] font-mono text-foreground/85 hover:text-foreground active:scale-[0.97] transition-all duration-150 ease-out"
               >
                 View on GitHub
               </a>

--- a/apps/web/components/homepage/footer.tsx
+++ b/apps/web/components/homepage/footer.tsx
@@ -276,7 +276,8 @@ const Footer = () => {
               { label: "vs Cursor", href: "/compare" },
               { label: "vs OpenCode", href: "/compare" },
               { label: "vs Claude Code", href: "/compare" },
-              { label: "vs Hermes Agent", href: "/compare" },
+              { label: "vs CommandCode", href: "/compare" },
+              { label: "vs FreeBuff", href: "/compare" },
             ]}
           />
           <LinkGroup

--- a/apps/web/components/homepage/navbar.tsx
+++ b/apps/web/components/homepage/navbar.tsx
@@ -161,7 +161,7 @@ const Navbar = () => {
 
   const navItems: Array<{ label: string; href: string; external?: boolean; accent?: boolean }> = [
     { label: "GitHub", href: "https://github.com/yashdev9274/superCli", external: true },
-    // { label: "Compare", href: "/compare" },
+    { label: "Compare", href: "/compare" },
     { label: "Docs", href: DOCS_URL, external: true },
     { label: "Changelog", href: "/changelog" },
     // { label: "Waitlist", href: "/waitlist", accent: true },


### PR DESCRIPTION
- Introduced a new slash command `/context` to display context window usage and breakdown.
- Implemented `renderContextBreakdown` function to format and output context information in the CLI.
- Updated command handling to include the new context command and adjusted the slash command list accordingly.
- Enhanced chat loop to track session usage and elapsed time for better context management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI **`/context`** command to display session metadata and token/context usage.
  * Updated the website **Compare** experience (new feature set and updated “Get started free” CTA).
* **Bug Fixes**
  * Improved CLI chat loop tracking and ensured the slash-command list layout accounts for the new command.
* **Style**
  * Refreshed Compare page UI (table structure, badges, cards, score bars) and updated navbar/footer Compare links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->