### PR TITLE
feat(supercode-cli): agent module, permission types, and mode simplification

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercode-cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "AI-powered coding agent CLI",
   "main": "dist/main.js",
   "bin": {

--- a/apps/supercode-cli/server/src/agent/__tests__/agent.test.ts
+++ b/apps/supercode-cli/server/src/agent/__tests__/agent.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from "bun:test"
+import { DefaultAgentService } from "../agent-service"
+import { registerBuiltInAgents } from "../built-in"
+
+describe("AgentService", () => {
+  const service = new DefaultAgentService()
+  registerBuiltInAgents(service)
+
+  test("get('plan') returns plan agent", () => {
+    const agent = service.get("plan")
+    expect(agent).toBeDefined()
+    expect(agent!.info.name).toBe("plan")
+    expect(agent!.info.mode).toBe("primary")
+  })
+
+  test("list() excludes hidden agents", () => {
+    const agents = service.list()
+    expect(agents.length).toBe(4)
+    expect(agents.find((a) => a.info.hidden)).toBeUndefined()
+  })
+
+  test("list({ includeHidden: true }) includes all 7", () => {
+    const agents = service.list({ includeHidden: true })
+    expect(agents.length).toBe(7)
+  })
+
+  test("plan agent denies write_file", () => {
+    const agent = service.get("plan")
+    const writeRule = agent!.info.permission.find(
+      (r) => r.permission === "write_file",
+    )
+    expect(writeRule?.action).toBe("deny")
+  })
+
+  test("build agent allows all tools", () => {
+    const agent = service.get("build")
+    const catchAll = agent!.info.permission.find(
+      (r) => r.permission === "*" && r.pattern === "*",
+    )
+    expect(catchAll?.action).toBe("allow")
+  })
+
+  test("explore agent is subagent mode", () => {
+    const agent = service.get("explore")
+    expect(agent!.info.mode).toBe("subagent")
+  })
+
+  test("compaction agent is hidden", () => {
+    const agent = service.get("compaction")
+    expect(agent!.info.hidden).toBe(true)
+  })
+
+  test("get('nonexistent') returns undefined", () => {
+    expect(service.get("nonexistent")).toBeUndefined()
+  })
+
+  test("register + unregister removes agent", () => {
+    service.register({
+      info: {
+        name: "test-agent",
+        mode: "primary",
+        options: {},
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      },
+    })
+    expect(service.get("test-agent")).toBeDefined()
+    service.unregister("test-agent")
+    expect(service.get("test-agent")).toBeUndefined()
+  })
+})

--- a/apps/supercode-cli/server/src/agent/agent-service.ts
+++ b/apps/supercode-cli/server/src/agent/agent-service.ts
@@ -1,0 +1,25 @@
+import type { AgentService, Agent } from "./agent"
+
+export class DefaultAgentService implements AgentService {
+  private agents = new Map<string, Agent>()
+
+  get(id: string): Agent | undefined {
+    return this.agents.get(id)
+  }
+
+  register(agent: Agent): void {
+    this.agents.set(agent.info.name, agent)
+  }
+
+  list(opts?: { includeHidden?: boolean }): Agent[] {
+    const all = Array.from(this.agents.values())
+    if (!opts?.includeHidden) {
+      return all.filter((a) => !a.info.hidden)
+    }
+    return all
+  }
+
+  unregister(id: string): void {
+    this.agents.delete(id)
+  }
+}

--- a/apps/supercode-cli/server/src/agent/agent.ts
+++ b/apps/supercode-cli/server/src/agent/agent.ts
@@ -1,0 +1,46 @@
+import type { RulesetArray } from "src/permission"
+
+export interface AgentInfo {
+  name: string
+  description?: string
+  mode: "subagent" | "primary" | "all"
+  native?: boolean
+  hidden?: boolean
+  topP?: number
+  temperature?: number
+  color?: string
+  permission: RulesetArray
+  model?: { modelID: string; providerID: string }
+  variant?: string
+  prompt?: string
+  options: Record<string, unknown>
+  steps?: number
+}
+
+export interface GenerateOptions {
+  model?: { modelID: string; providerID: string }
+  onStepFinish?: (step: unknown) => void
+  signal?: AbortSignal
+}
+
+export interface GenerateResult {
+  text: string
+  toolCalls?: unknown[]
+  finishReason?: string
+}
+
+export interface Agent {
+  info: AgentInfo
+  generate?: (
+    sessionId: string,
+    prompt: string,
+    opts?: GenerateOptions,
+  ) => Promise<GenerateResult>
+}
+
+export interface AgentService {
+  get(id: string): Agent | undefined
+  register(agent: Agent): void
+  list(opts?: { includeHidden?: boolean }): Agent[]
+  unregister(id: string): void
+}

--- a/apps/supercode-cli/server/src/agent/built-in.ts
+++ b/apps/supercode-cli/server/src/agent/built-in.ts
@@ -1,0 +1,111 @@
+import type { AgentService, AgentInfo } from "./agent"
+import type { RulesetArray } from "src/permission"
+
+function info(
+  overrides: Partial<AgentInfo> & { name: string; permission: RulesetArray },
+): AgentInfo {
+  return {
+    mode: "primary",
+    native: true,
+    hidden: false,
+    temperature: 0,
+    options: {},
+    ...overrides,
+  }
+}
+
+const buildInfo: AgentInfo = info({
+  name: "build",
+  description: "Full-stack application builder with write access. The default agent.",
+  permission: [
+    { permission: "*", pattern: "*", action: "allow" },
+    { permission: "run_command", pattern: "rm -rf *", action: "deny", reason: "Destructive" },
+  ],
+})
+
+const planInfo: AgentInfo = info({
+  name: "plan",
+  description: "Read-only code analysis and planning. Cannot modify files.",
+  permission: [
+    { permission: "read_file", pattern: "*", action: "allow" },
+    { permission: "search_files", pattern: "*", action: "allow" },
+    { permission: "url_fetch", pattern: "*", action: "allow" },
+    { permission: "web_search", pattern: "*", action: "allow" },
+    { permission: "read_instructions", pattern: "*", action: "allow" },
+    { permission: "write_file", pattern: "*", action: "deny", reason: "Plan mode is read-only" },
+    { permission: "run_command", pattern: "*", action: "deny", reason: "Plan mode is read-only" },
+    { permission: "code_exec", pattern: "*", action: "deny", reason: "Plan mode is read-only" },
+    { permission: "*", pattern: "*", action: "deny" },
+  ],
+})
+
+const generalInfo: AgentInfo = info({
+  name: "general",
+  description: "General-purpose agent for researching complex questions and executing multi-step tasks.",
+  mode: "subagent",
+  permission: [
+    { permission: "*", pattern: "*", action: "allow" },
+    { permission: "todowrite", pattern: "*", action: "deny" },
+  ],
+})
+
+const exploreInfo: AgentInfo = info({
+  name: "explore",
+  description: "Fast file search specialist. Reads and searches only — no modifications.",
+  mode: "subagent",
+  permission: [
+    { permission: "*", pattern: "*", action: "deny" },
+    { permission: "grep", pattern: "*", action: "allow" },
+    { permission: "glob", pattern: "*", action: "allow" },
+    { permission: "list", pattern: "*", action: "allow" },
+    { permission: "bash", pattern: "*", action: "allow" },
+    { permission: "webfetch", pattern: "*", action: "allow" },
+    { permission: "websearch", pattern: "*", action: "allow" },
+    { permission: "read", pattern: "*", action: "allow" },
+    { permission: "search_files", pattern: "*", action: "allow" },
+    { permission: "url_fetch", pattern: "*", action: "allow" },
+    { permission: "web_search", pattern: "*", action: "allow" },
+    { permission: "read_file", pattern: "*", action: "allow" },
+    { permission: "read_instructions", pattern: "*", action: "allow" },
+  ],
+  prompt: "prompts/explore.txt",
+})
+
+const compactionInfo: AgentInfo = info({
+  name: "compaction",
+  description: "Internal agent for context compaction.",
+  hidden: true,
+  permission: [{ permission: "*", pattern: "*", action: "deny" }],
+  prompt: "prompts/compaction.txt",
+})
+
+const titleInfo: AgentInfo = info({
+  name: "title",
+  description: "Internal agent for conversation title generation.",
+  hidden: true,
+  temperature: 0.5,
+  permission: [{ permission: "*", pattern: "*", action: "deny" }],
+  prompt: "prompts/title.txt",
+})
+
+const summaryInfo: AgentInfo = info({
+  name: "summary",
+  description: "Internal agent for session summary generation.",
+  hidden: true,
+  permission: [{ permission: "*", pattern: "*", action: "deny" }],
+  prompt: "prompts/summary.txt",
+})
+
+export function registerBuiltInAgents(service: AgentService): void {
+  for (const agentInfo of [
+    buildInfo,
+    planInfo,
+    generalInfo,
+    exploreInfo,
+    compactionInfo,
+    titleInfo,
+    summaryInfo,
+  ]) {
+    service.register({ info: agentInfo })
+  }
+}

--- a/apps/supercode-cli/server/src/agent/index.ts
+++ b/apps/supercode-cli/server/src/agent/index.ts
@@ -1,0 +1,11 @@
+export {
+  type Agent,
+  type AgentInfo,
+  type AgentService,
+  type GenerateOptions,
+  type GenerateResult,
+} from "./agent"
+
+export { DefaultAgentService } from "./agent-service"
+export { registerBuiltInAgents } from "./built-in"
+export { agentService } from "./singleton"

--- a/apps/supercode-cli/server/src/agent/prompts/compaction.txt
+++ b/apps/supercode-cli/server/src/agent/prompts/compaction.txt
@@ -1,0 +1,16 @@
+You are an anchored context summarization assistant for coding sessions.
+
+Your task:
+- Summarize ONLY the given conversation history
+- Newest turns may be kept verbatim outside the summary
+- If a <previous-summary> block exists, update it:
+  - Preserve information that is still true
+  - Remove stale information
+  - Merge in new information
+- Follow the exact output structure requested
+- Preserve exact file paths and identifiers
+- Prefer terse bullets over paragraphs
+- Do not mention that you are summarizing
+- Match the conversation's language
+
+Output ONLY the summary, no preamble or explanation.

--- a/apps/supercode-cli/server/src/agent/prompts/explore.txt
+++ b/apps/supercode-cli/server/src/agent/prompts/explore.txt
@@ -1,0 +1,15 @@
+You are a file search specialist. Your job is to find files and code quickly.
+
+Guidelines:
+- Use glob for broad pattern matching
+- Use grep for regex content search
+- Use read for known file paths
+- Use bash for read-only file operations (ls, cp, mv)
+
+Restrictions:
+- Do NOT create or modify any files
+- Do NOT modify system state
+- Return absolute paths in your responses
+- No emojis
+
+Be concise. Focus on finding what the user asked for.

--- a/apps/supercode-cli/server/src/agent/prompts/summary.txt
+++ b/apps/supercode-cli/server/src/agent/prompts/summary.txt
@@ -1,0 +1,2 @@
+Summarize the key topics, decisions, and open items from this conversation.
+Focus on actionable information. Be concise. Output only the summary.

--- a/apps/supercode-cli/server/src/agent/prompts/title.txt
+++ b/apps/supercode-cli/server/src/agent/prompts/title.txt
@@ -1,0 +1,13 @@
+Generate a concise conversation title.
+
+Constraints:
+- Single line, 50 characters or fewer
+- Same language as the user's message
+- No tool names in the title
+- Focus on the main topic or question
+- Keep exact: technical terms, numbers, filenames, HTTP codes
+- Remove: the, this, my, a, an
+- Never assume a tech stack
+- Never respond to questions — just output the title
+
+Output ONLY the title, nothing else.

--- a/apps/supercode-cli/server/src/agent/singleton.ts
+++ b/apps/supercode-cli/server/src/agent/singleton.ts
@@ -1,0 +1,7 @@
+import { DefaultAgentService } from "./agent-service"
+import { registerBuiltInAgents } from "./built-in"
+
+const agentService = new DefaultAgentService()
+registerBuiltInAgents(agentService)
+
+export { agentService }

--- a/apps/supercode-cli/server/src/cli/ai/chat/chat.ts
+++ b/apps/supercode-cli/server/src/cli/ai/chat/chat.ts
@@ -39,6 +39,7 @@ import { renderWorkspaceBanner } from "src/cli/workspace/format.ts"
 import { handleSlashCommand, isSlashCommand } from "src/cli/commands/slashCommands/index.ts"
 import { renderContextBreakdown } from "src/cli/commands/slashCommands/context-window.ts"
 import { saveCliConfig } from "src/lib/cli-config"
+import { agentService } from "src/agent"
 
 async function getUserFromToken() {
   const token = await getStoredToken()
@@ -88,7 +89,7 @@ async function streamAIResponse(
 
   if (workspaceInfo) {
     process.env.SUPERCODE_WORKSPACE_ROOT = workspaceInfo.workspaceRoot
-    const hasTools = mode === "tool" || mode === "agent"
+    const hasTools = mode === "agent" || mode === "chat"
     const systemPrompt = buildSystemPrompt(workspaceInfo, hasTools)
     aiMessages = [
       { role: "system", content: systemPrompt },
@@ -106,8 +107,21 @@ async function streamAIResponse(
   thinking.start("thinking")
 
   let toolsToUse: Record<string, unknown> | undefined
-  if (workspaceInfo && (mode === "tool" || mode === "agent")) {
+  if (workspaceInfo && mode === "agent") {
     toolsToUse = { ...tools }
+  } else if (workspaceInfo && mode === "chat") {
+    const chatAgent = agentService.get("plan")
+    if (chatAgent) {
+      const allowed = new Set<string>()
+      for (const r of chatAgent.info.permission) {
+        if (r.action === "allow" && r.permission !== "*") {
+          allowed.add(r.permission)
+        }
+      }
+      toolsToUse = Object.fromEntries(
+        Object.entries(tools).filter(([name]) => allowed.has(name)),
+      )
+    }
   }
 
   function emitHeader() {
@@ -177,15 +191,13 @@ interface Conversation {
   updatedAt: Date
 }
 
-const modes = ["chat", "tool", "agent"]
+const modes = ["chat", "agent"]
 const modeColors: Record<string, string> = {
   chat: theme.cyan,
-  tool: theme.green,
   agent: theme.warning,
 }
 const modeDisplay: Record<string, string> = {
   chat: "chat",
-  tool: "tools",
   agent: "agent",
 }
 
@@ -297,7 +309,7 @@ function stdinKeypress(_str: string, key: any) {
   if (key.name === "tab") {
     const idx = modes.indexOf(stdinMode)
     stdinMode = modes[(idx + 1) % modes.length]!
-    if (stdinMode === "agent" || stdinMode === "tool") {
+    if (stdinMode === "agent") {
       permissionManager.setSessionLevel("allow")
     } else {
       permissionManager.setSessionLevel(null)
@@ -511,7 +523,7 @@ function setupStdin() {
 
 async function chatInput(currentMode: string): Promise<{ input: string; mode: string }> {
   stdinMode = modes.includes(currentMode) ? currentMode : "chat"
-  if (stdinMode === "agent" || stdinMode === "tool") {
+  if (stdinMode === "agent") {
     permissionManager.setSessionLevel("allow")
   } else {
     permissionManager.setSessionLevel(null)
@@ -609,7 +621,7 @@ export async function chatLoop(
             contextWindow = getContextWindow(provider.modelName)
             const label = result.label || provider.modelName
             process.stdout.write(`\r\n ${chalk.hex(theme.green)("◆")} switched to ${chalk.hex(theme.cyan)(label)}\r\n\n`)
-            saveCliConfig({ provider: result.provider!, model: result.model || provider.modelName, mode: conversation.mode as "chat" | "tools" | "agent" })
+            saveCliConfig({ provider: result.provider!, model: result.model || provider.modelName, mode: conversation.mode as "chat" | "agent" })
           }
         } else if (result?.type === "connect") {
           if (result.provider) {
@@ -714,8 +726,8 @@ export async function startChat(
 
     const aiProvider = createProvider(provider, model)
 
-    const modeLabel = initialMode === "tool" ? "tools" : initialMode === "agent" ? "agent" : "chat"
-    const subtitle = modeLabel === "chat" ? `ai chat · ${aiProvider.modelName}` : `${modeLabel} · ${aiProvider.modelName}`
+    const modeLabel = initialMode === "agent" ? "agent" : "chat"
+    const subtitle = modeLabel === "chat" ? `ai chat · ${aiProvider.modelName}` : `agent · ${aiProvider.modelName}`
 
     // ── Header ───────────────────────────────────────────────────
     const w = process.stdout.columns ?? 80

--- a/apps/supercode-cli/server/src/cli/ai/chat/chatAgent.ts
+++ b/apps/supercode-cli/server/src/cli/ai/chat/chatAgent.ts
@@ -6,6 +6,7 @@ import { getStoredToken } from "src/lib/token"
 import { ChatService } from "src/service/chat-service"
 import { createProvider, type ModelProvider } from "src/cli/ai/provider"
 import { createAppAgent } from "src/config/agent-config"
+import { agentService } from "src/agent"
 
 let _chatService: ChatService
 

--- a/apps/supercode-cli/server/src/cli/utils/tui.ts
+++ b/apps/supercode-cli/server/src/cli/utils/tui.ts
@@ -1047,7 +1047,7 @@ export function chatHelp() {
   const lines = [
     ` ${chalk.hex(theme.amber)("Enter")}     send message`,
     ` ${chalk.hex(theme.amber)("Esc")}      clear input / cancel response`,
-    ` ${chalk.hex(theme.amber)("Tab")}      cycle mode · ${chalk.hex(theme.greenGlow)("[chat] [tools] [agent]")}`,
+    ` ${chalk.hex(theme.amber)("Tab")}      cycle mode · ${chalk.hex(theme.greenGlow)("[chat] [agent]")}`,
     ` ${chalk.hex(theme.amber)("↑/↓")}     navigate history`,
     ` ${chalk.hex(theme.amber)("Ctrl+C")}   exit`,
   ]

--- a/apps/supercode-cli/server/src/lib/cli-config.ts
+++ b/apps/supercode-cli/server/src/lib/cli-config.ts
@@ -11,7 +11,7 @@ export interface CliConfig {
   version: string
   provider: ModelProvider
   model: string
-  mode: "chat" | "tools" | "agent"
+  mode: "chat" | "agent"
   apiKeys?: Partial<Record<ModelProvider, string>>
 }
 

--- a/apps/supercode-cli/server/src/permission/index.ts
+++ b/apps/supercode-cli/server/src/permission/index.ts
@@ -1,0 +1,53 @@
+export type PermissionEffect = "deny" | "ask" | "allow"
+
+export interface Ruleset {
+  permission: string
+  pattern: string
+  action: PermissionEffect
+  reason?: string
+}
+
+export type RulesetArray = Ruleset[]
+
+export interface SessionPermission {
+  deny: RulesetArray
+  allow: RulesetArray
+  ask: RulesetArray
+  rules: RulesetArray
+}
+
+export function mergePermissions(...rulesets: RulesetArray[]): RulesetArray {
+  return rulesets.flat()
+}
+
+export function permissionFromConfig(
+  config: Record<string, string | Record<string, string>>,
+): RulesetArray {
+  const rules: RulesetArray = []
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === "string") {
+      rules.push({
+        permission: key,
+        pattern: "*",
+        action: value as PermissionEffect,
+      })
+    } else {
+      for (const [pattern, action] of Object.entries(value)) {
+        rules.push({
+          permission: key,
+          pattern,
+          action: action as PermissionEffect,
+        })
+      }
+    }
+  }
+  return rules
+}
+
+export function wildcardMatch(input: string, pattern: string): boolean {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".")
+  return new RegExp("^" + escaped + "$", "s").test(input)
+}


### PR DESCRIPTION
## Summary

Introduces the agent registry with 7 built-in agents, a shared permission type
system, and simplifies the chat mode UX from 4 modes → 2 modes.

## Changes

### New: Permission Module (`server/src/permission/index.ts`)
- `Ruleset`, `SessionPermission` types with opencode-compatible field naming
- `mergePermissions`, `permissionFromConfig`, `wildcardMatch` utilities
- Coexists with existing `permission-manager.ts` (no refactor)

### New: Agent Module (`server/src/agent/`)
- `AgentInfo` schema (14 fields: name, mode, permission, model, prompt, etc.)
- `AgentService` interface + `DefaultAgentService` implementation
- 7 built-in agents with permission profiles:
  - **build**: full access (except `rm -rf`)
  - **plan**: read-only (read_file, search_files, url_fetch, web_search, read_instructions)
  - **general**: subagent for multi-step tasks
  - **explore**: subagent for fast file search (no modifications)
  - **compaction/title/summary**: hidden internal agents
- Agent prompt files (compaction.txt, explore.txt, title.txt, summary.txt)
- Singleton with auto-registration

### Mode Simplification
| Before | After | Behavior |
|---|---|---|
| chat + plan | **chat** | Conversation + read-only filtered tools |
| tool + agent | **agent** | Full workspace + all tools + autonomous loop |

- `CliConfig.mode` type narrowed from `"chat" | "tools" | "agent"` → `"chat" | "agent"`
- Tab cycling simplified, `hasTools` correctly set for both modes

### Tests
- 9 test cases covering: lookup, list filtering, hidden agents, permission checks,
  register/unregister lifecycle (all passing)