### PR TITLE
chore: bump version to 0.1.17 and add GLM 5.2 support

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercode-cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "AI-powered coding agent CLI",
   "main": "dist/main.js",
   "bin": {

--- a/apps/supercode-cli/server/src/cli/ai/context-windows.ts
+++ b/apps/supercode-cli/server/src/cli/ai/context-windows.ts
@@ -14,6 +14,7 @@ const CONTEXT_WINDOWS: Record<string, number> = {
   "minimaxai/minimax-m2.7": 1_000_000,
   "deepseek-v4-flash": 128_000,
   "kimi-k2-6": 262_144,
+  "glm-5.2": 203_000,
   "glm-5.1": 203_000,
   "minimax-m2-7": 1_000_000,
 }

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/help.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/help.ts
@@ -12,7 +12,7 @@ const PROVIDERS = [
   { name: "Google Gemini", models: ["gemini-2.5-flash", "gemini-2.5-pro"], note: "free · multimodal" },
   { name: "OpenRouter", models: ["openai/gpt-oss-120b:free", "deepseek/deepseek-v4-flash", "minimax/minimax-m3", "z-ai/glm-5.1", "moonshotai/kimi-k2.6"], note: "bring your own key" },
   { name: "NVIDIA NIM", models: ["minimaxai/minimax-m2.7", "deepseek-ai/deepseek-v4-flash", "meta/llama-3.3-70b-instruct"], note: "free API" },
-  { name: "ConcentrateAI", models: ["deepseek-v4-flash", "kimi-k2-6", "glm-5.1", "minimax-m2-7"], note: "AI gateway" },
+  { name: "ConcentrateAI", models: ["deepseek-v4-flash", "kimi-k2-6", "glm-5.2", "glm-5.1", "minimax-m2-7"], note: "AI gateway" },
 ]
 
 function renderCommands(): string {

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/model.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/model.ts
@@ -13,6 +13,7 @@ interface ModelEntry {
 }
 
 const MODELS: ModelEntry[] = [
+  { value: "glm-5.2", label: "GLM 5.2", provider: "concentrateai", cost: "0.5x", desc: "Latest GLM" },
   { value: "glm-5.1", label: "GLM 5.1", provider: "concentrateai", cost: "0.4x", desc: "Balanced multilingual" },
   { value: "kimi-k2-6", label: "Kimi K2.6", provider: "concentrateai", cost: "0.8x", desc: "Long context" },
   { value: "deepseek-v4-flash", label: "DeepSeek V4 Flash", provider: "concentrateai", cost: "1.0x", desc: "Fast & capable" },

--- a/apps/supercode-cli/server/src/index.ts
+++ b/apps/supercode-cli/server/src/index.ts
@@ -19,6 +19,7 @@ const MODEL_MAX_TOKENS: Record<string, number> = {
   "z-ai/glm-5.1": 512,
   "deepseek-v4-flash": 8192,
   "kimi-k2-6": 8192,
+  "glm-5.2": 4096,
   "glm-5.1": 4096,
   "minimax-m2-7": 8192,
 }

--- a/apps/web/app/(pages)/changelog/page.tsx
+++ b/apps/web/app/(pages)/changelog/page.tsx
@@ -37,9 +37,10 @@ export default function ChangelogPage() {
               <div>
                 <h3 className="text-[17px] text-white font-semibold mb-3 text-muted-foreground uppercase tracking-wider">CLI / TUI</h3>
                 <ul className="space-y-3 text-[14px] leading-relaxed text-foreground/85">
-                  <li>- <strong>4 modes → 2.</strong> Chat, tool, agent, and plan modes collapsed into two: <strong>chat</strong> (read-only tools: search, fetch, browse) and <strong>agent</strong> (full workspace + all tools).</li>
+                  <li>- <strong>4 modes → 2.</strong> Chat, tool, agent, and plan modes collapsed into two: <strong>chat</strong> (read-only workspace access: read_file, search_files, url_fetch, browse, etc.) and <strong>agent</strong> (full workspace + all tools, including write).</li>
                   <li>- New <strong>AgentService</strong> with 7 built-in agents (build, plan, general, explore, compaction, title, summary) each with permission profiles and prompt files.</li>
                   <li>- New <strong>permission module</strong> — Ruleset types, wildcard matching, and <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">mergePermissions</code> for granular tool access control.</li>
+                  <li>- <strong>GLM 5.2</strong> added to ConcentrateAI provider.</li>
                   <li>- New <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">/context-window</code> slash command — shows token usage breakdown per message with context percentage. 240-line implementation with detailed rendering.</li>
                   <li>- Narrowed <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">CliConfig.mode</code> type to <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">"chat" | "agent"</code>.</li>
                 </ul>


### PR DESCRIPTION
- Updated package version to 0.1.17.
- Added GLM 5.2 model with corresponding context window and token settings to the CLI.
- Updated help documentation to include GLM 5.2 in the ConcentrateAI provider.