### PR TITLE
chore: bump version to 0.1.22 and improve update error handling

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercode-cli",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "AI-powered coding agent CLI",
   "main": "dist/main.js",
   "bin": {

--- a/apps/supercode-cli/server/src/cli/utils/auto-update.ts
+++ b/apps/supercode-cli/server/src/cli/utils/auto-update.ts
@@ -6,13 +6,13 @@ import { confirm, isCancel } from "@clack/prompts"
 const NPM_PACKAGE = "supercode-cli"
 
 export async function checkForUpdate(): Promise<void> {
+  const thinking = createThinking("checking for update")
   try {
-    const thinking = createThinking("checking for update")
     const res = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE}/latest`, {
       signal: AbortSignal.timeout(5000),
     })
     if (!res.ok) {
-      thinking.fail()
+      thinking.fail("could not reach registry")
       return
     }
     const data = (await res.json()) as { version: string }
@@ -56,6 +56,6 @@ export async function checkForUpdate(): Promise<void> {
       console.log()
     }
   } catch {
-    // Network error or timeout — continue silently
+    thinking.fail("update check failed")
   }
 }


### PR DESCRIPTION
- Updated package version to 0.1.22.
- Enhanced error handling in the auto-update feature to provide clearer failure messages when the registry cannot be reached or when the update check fails.