### PR TITLE
chore: update dependencies and bump version to 0.1.23

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -42,7 +42,9 @@
   "dependencies": {
     "@ai-sdk/openai-compatible": "^2.0.48",
     "@prisma/adapter-pg": "^7.8.0",
-    "@prisma/client": "^7.8.0"
+    "@prisma/client": "^7.8.0",
+    "@prisma/client-runtime-utils": "^7.8.0",
+    "@prisma/driver-adapter-utils": "^7.8.0"
   },
   "devDependencies": {
     "@ai-sdk/google": "^3.0.80",

--- a/bun.lock
+++ b/bun.lock
@@ -89,20 +89,22 @@
     },
     "apps/supercode-cli/server": {
       "name": "supercode-cli",
-      "version": "0.1.20",
+      "version": "0.1.23",
       "bin": {
         "supercode": "dist/main.js",
       },
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.48",
+        "@prisma/adapter-pg": "^7.8.0",
+        "@prisma/client": "^7.8.0",
+        "@prisma/client-runtime-utils": "^7.8.0",
+        "@prisma/driver-adapter-utils": "^7.8.0",
       },
       "devDependencies": {
         "@ai-sdk/google": "^3.0.80",
         "@clack/prompts": "^1.5.0",
         "@openrouter/ai-sdk-provider": "^2.9.0",
         "@openrouter/sdk": "^0.12.79",
-        "@prisma/adapter-pg": "^7.8.0",
-        "@prisma/client": "^7.8.0",
         "@super/db-terminal": "workspace:*",
         "@types/bun": "^1.3.14",
         "@types/cors": "^2.8.17",


### PR DESCRIPTION
- Updated package version to 0.1.23.
- Added new Prisma-related dependencies: `@prisma/client-runtime-utils` and `@prisma/driver-adapter-utils` for improved functionality.
- Cleaned up dependency management in `package.json` and `bun.lock` files.