### PR TITLE
feat: add Claude Opus 4.8 integration through ConcentrateAI with daily budget caps

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercode-cli",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "AI-powered coding agent CLI",
   "main": "dist/main.js",
   "bin": {

--- a/apps/supercode-cli/server/src/cli/ai/concentrate-service.ts
+++ b/apps/supercode-cli/server/src/cli/ai/concentrate-service.ts
@@ -1,8 +1,9 @@
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
-import { streamText, stepCountIs, type ModelMessage, type LanguageModel } from "ai"
+import { streamText, stepCountIs, type ModelMessage, type LanguageModel, type LanguageModelUsage } from "ai"
 import chalk from "chalk"
 import { recordUsage } from "../../lib/track-usage"
 import { computeCost } from "../../lib/pricing"
+import { checkDailyBudget, checkQueryLimit, DAILY_QUERY_LIMIT, OPUS_MODEL_ID, getOrCreateDeviceId } from "../../lib/token-budget"
 import { isEmptyToolResult, isDeniedToolResult, summarizeToolResult, tcName } from "./tool-result"
 
 const CONCENTRATE_API_KEY = process.env.CONCENTRATEAI_API_KEY || ""
@@ -77,6 +78,37 @@ export class ConcentrateService {
     const signalHandler = signal ? () => streamAbortController.abort() : undefined
     signalHandler && signal!.addEventListener("abort", signalHandler, { once: true })
 
+    const isOpus = this.modelName === OPUS_MODEL_ID
+    const deviceId = await getOrCreateDeviceId()
+
+    if (isOpus) {
+      const [tokenBudget, queryLimit] = await Promise.all([
+        checkDailyBudget(),
+        checkQueryLimit(deviceId),
+      ])
+
+      if (!tokenBudget.allowed || !queryLimit.allowed) {
+        const reasons: string[] = []
+        if (!tokenBudget.allowed) reasons.push(`Token budget used: ${tokenBudget.used.toLocaleString()} / ${128_000..toLocaleString()}`)
+        if (!queryLimit.allowed) reasons.push(`Query limit used: ${queryLimit.used} / ${DAILY_QUERY_LIMIT}`)
+        const msg = [
+          chalk.red("╔══ Daily usage limit exceeded ══╗"),
+          chalk.red(`║  Model: anthropic/claude-opus-4-8`),
+          ...reasons.map(r => chalk.red(`║  ${r}`)),
+          chalk.red(`║  Resets: ${new Date(tokenBudget.resetTime).toLocaleDateString()}`),
+          chalk.red(`╚════════════════════════════════════╝`),
+          ``,
+          chalk.yellow(`ℹ Switch to ${chalk.cyan("/model minimax-m3")} to continue chatting.`),
+          `Run ${chalk.cyan("/usage")} to check your usage across all models.`,
+        ].join("\n")
+        return {
+          content: msg,
+          finishReason: "stop" as const,
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, inputTokenDetails: {}, outputTokenDetails: {} } as LanguageModelUsage,
+        }
+      }
+    }
+
     try {
       const systemMessages = messages.filter(m => m.role === "system")
       const nonSystemMessages = messages.filter(m => m.role !== "system")
@@ -120,6 +152,7 @@ export class ConcentrateService {
             totalTokens: inputTokens + outputTokens,
             costUsd: computeCost(this.modelName, inputTokens, outputTokens, 0),
             durationMs: null,
+            userId: deviceId,
           })
           return {
             content,
@@ -155,6 +188,7 @@ export class ConcentrateService {
           totalTokens: usage.totalTokens ?? 0,
           costUsd: computeCost(this.modelName, usage.inputTokens ?? 0, usage.outputTokens ?? 0, usage.inputTokenDetails?.cacheReadTokens ?? 0),
           durationMs: null,
+          userId: deviceId,
         })
 
         return {
@@ -182,7 +216,7 @@ export class ConcentrateService {
         messages: nonSystemMessages,
         system,
         tools,
-        stopWhen: stepCountIs(8),
+        stopWhen: stepCountIs(isOpus ? 5 : 8),
         abortSignal: streamAbortController.signal,
         prepareStep: async ({ messages }) => {
           if (stopForDenialLoop) {
@@ -296,6 +330,7 @@ export class ConcentrateService {
           totalTokens: inputTokens + outputTokens,
           costUsd: computeCost(this.modelName, inputTokens, outputTokens, 0),
           durationMs: null,
+          userId: deviceId,
         })
         return {
           content,
@@ -326,19 +361,20 @@ export class ConcentrateService {
         provider: "concentrateai",
         model: this.modelName,
         inputTokens: usage.inputTokens ?? 0,
-        outputTokens: usage.outputTokens ?? 0,
-        cachedInputTokens: usage.inputTokenDetails?.cacheReadTokens ?? 0,
-        totalTokens: usage.totalTokens ?? 0,
-        costUsd: computeCost(this.modelName, usage.inputTokens ?? 0, usage.outputTokens ?? 0, usage.inputTokenDetails?.cacheReadTokens ?? 0),
-        durationMs: null,
-      })
+          outputTokens: usage.outputTokens ?? 0,
+          cachedInputTokens: usage.inputTokenDetails?.cacheReadTokens ?? 0,
+          totalTokens: usage.totalTokens ?? 0,
+          costUsd: computeCost(this.modelName, usage.inputTokens ?? 0, usage.outputTokens ?? 0, usage.inputTokenDetails?.cacheReadTokens ?? 0),
+          durationMs: null,
+          userId: deviceId,
+        })
 
-      return {
-        content: fullResponse,
-        finishReason,
-        usage,
-      }
-    } catch (error: any) {
+        return {
+          content: fullResponse,
+          finishReason,
+          usage,
+        }
+      } catch (error: any) {
       if (error?.name === "AbortError") throw error
       console.error(chalk.red("ConcentrateAI Service Error:"), error instanceof Error ? error.message : String(error))
       throw error

--- a/apps/supercode-cli/server/src/cli/ai/context-windows.ts
+++ b/apps/supercode-cli/server/src/cli/ai/context-windows.ts
@@ -17,6 +17,7 @@ const CONTEXT_WINDOWS: Record<string, number> = {
   "glm-5.2": 203_000,
   "glm-5.1": 203_000,
   "minimax-m3": 1_000_000,
+  "anthropic/claude-opus-4-8": 500_000,
 }
 
 const FALLBACK_CONTEXT_WINDOW = 128_000

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/index.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/index.ts
@@ -1,6 +1,7 @@
 import { select, isCancel } from "@clack/prompts"
 import chalk from "chalk"
 import { pickModel, formatModelChange } from "./model.ts"
+import { usageCommand } from "./usage.ts"
 import { connectProvider } from "./connect.ts"
 import { renderHelp } from "./help.ts"
 import { theme, heavyDivider } from "src/cli/utils/tui.ts"
@@ -28,6 +29,7 @@ export const COMMANDS = [
   { cmd: "/interact", desc: "Browser interaction via Firecrawl" },
   { cmd: "/crawl", desc: "Crawl a website via Firecrawl" },
   { cmd: "/parse", desc: "Parse a file (PDF, DOC, etc.) via Firecrawl" },
+  { cmd: "/usage", desc: "Show daily token usage and budget for Opus 4.8" },
   { cmd: "/help", desc: "Show available commands and models" },
   { cmd: "/exit", desc: "End the session" },
 ]
@@ -82,6 +84,10 @@ const handlers: Record<string, (args: string) => Promise<SlashCommandResult>> = 
   },
   verbose: async () => {
     return { type: "verbose" }
+  },
+  usage: async () => {
+    await usageCommand()
+    return { type: "help" as const }
   },
   search: async (args) => ({ type: "message", message: chatify("search", args) }),
   scrape: async (args) => ({ type: "message", message: chatify("scrape", args) }),

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/model.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/model.ts
@@ -13,6 +13,7 @@ interface ModelEntry {
 }
 
 const MODELS: ModelEntry[] = [
+  { value: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8", provider: "concentrateai", cost: "5.0x", desc: "Top-tier reasoning" },
   { value: "glm-5.2", label: "GLM 5.2", provider: "concentrateai", cost: "0.5x", desc: "Latest GLM" },
   { value: "glm-5.1", label: "GLM 5.1", provider: "concentrateai", cost: "0.4x", desc: "Balanced multilingual" },
   { value: "kimi-k2-6", label: "Kimi K2.6", provider: "concentrateai", cost: "0.8x", desc: "Long context" },
@@ -58,7 +59,8 @@ function renderModelBrowser(currentProvider: string, currentModel: string): void
       const cost = chalk.hex(m.cost === "free" ? theme.greenGlow : theme.muted)(m.cost.padEnd(6))
       const desc = chalk.hex(theme.muted)(m.desc.padEnd(20))
       const marker = isCurrent ? ` ${chalk.bgHex(theme.amber).hex(theme.black).bold(" current ")}` : ""
-      console.log(`  ${prefix} ${name} ${cost}${desc}${marker}`)
+      const freeTag = !isCurrent && providerKey === "concentrateai" ? ` ${chalk.bgHex(theme.green).hex(theme.black).bold(" FREE ")}` : ""
+      console.log(`  ${prefix} ${name} ${cost}${desc}${marker}${freeTag}`)
     }
     console.log()
   }

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/usage.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/usage.ts
@@ -1,0 +1,85 @@
+import chalk from "chalk"
+import prisma from "src/lib/prisma"
+import { theme, sectionHeader, heavyDivider, formatTokenCount } from "src/cli/utils/tui.ts"
+import { OPUS_MODEL_ID, DAILY_BUDGET_TOKENS, DAILY_QUERY_LIMIT, getDailyTokenUsage, getDailyQueryCount, getOrCreateDeviceId } from "src/lib/token-budget"
+
+function todayStart(): Date {
+  const now = new Date()
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+}
+
+export async function usageCommand(): Promise<void> {
+  const today = todayStart()
+  const tomorrow = new Date(today.getTime() + 86_400_000)
+
+  const [total, deviceId] = await Promise.all([
+    getDailyTokenUsage(OPUS_MODEL_ID),
+    getOrCreateDeviceId(),
+  ])
+  const queryCount = await getDailyQueryCount(deviceId)
+
+  const tokenRemaining = Math.max(0, DAILY_BUDGET_TOKENS - total)
+  const tokenPct = Math.min(100, Math.round((total / DAILY_BUDGET_TOKENS) * 100))
+  const queryRemaining = Math.max(0, DAILY_QUERY_LIMIT - queryCount)
+  const queryPct = Math.min(100, Math.round((queryCount / DAILY_QUERY_LIMIT) * 100))
+
+  const todayLabel = today.toLocaleDateString()
+  const w = Math.min(process.stdout.columns ?? 80, 72)
+
+  console.log()
+  console.log(heavyDivider())
+  console.log()
+  console.log(sectionHeader("Daily Limits — Claude Opus 4.8", { accent: "green" }))
+
+  const barWidth = w - 20
+
+  console.log(`  ${chalk.hex(theme.greenGlow).bold("Token Budget")}`)
+  console.log(`  ${chalk.hex(theme.muted)(todayLabel)}`)
+  const tokenBar = chalk.hex(tokenPct >= 80 ? theme.red : theme.green)("█".repeat(Math.round((tokenPct / 100) * barWidth))) +
+    chalk.hex(theme.greenDim)("█".repeat(Math.max(0, barWidth - Math.round((tokenPct / 100) * barWidth))))
+  console.log(`  ${tokenBar} ${chalk.hex(theme.muted)(`${tokenPct}%`)}`)
+  console.log(`  ${chalk.hex(theme.greenMute)("Used")}      ${formatTokenCount(total).padStart(8)} ${chalk.hex(theme.dim)(`/ ${formatTokenCount(DAILY_BUDGET_TOKENS)}`)}`)
+  console.log(`  ${chalk.hex(theme.greenMute)("Remaining")} ${formatTokenCount(tokenRemaining).padStart(8)}`)
+  console.log()
+
+  console.log(`  ${chalk.hex(theme.greenGlow).bold("Query Limit")}`)
+  const queryBar = chalk.hex(queryPct >= 80 ? theme.red : theme.green)("█".repeat(Math.round((queryPct / 100) * barWidth))) +
+    chalk.hex(theme.greenDim)("█".repeat(Math.max(0, barWidth - Math.round((queryPct / 100) * barWidth))))
+  console.log(`  ${queryBar} ${chalk.hex(theme.muted)(`${queryPct}%`)}`)
+  console.log(`  ${chalk.hex(theme.greenMute)("Used")}      ${String(queryCount).padStart(8)} ${chalk.hex(theme.dim)(`/ ${DAILY_QUERY_LIMIT}`)}`)
+  console.log(`  ${chalk.hex(theme.greenMute)("Remaining")} ${String(queryRemaining).padStart(8)}`)
+  console.log(`  ${chalk.hex(theme.greenMute)("Resets")}    ${tomorrow.toLocaleDateString()}`)
+
+  if (tokenPct >= 80 || queryPct >= 80) {
+    console.log()
+    const warnings: string[] = []
+    if (tokenPct >= 80) warnings.push("Token budget nearly exhausted")
+    if (queryPct >= 80) warnings.push("Query limit nearly exhausted")
+    console.log(`  ${chalk.hex(theme.red)(`⚠  ${warnings.join(" — ")}`)}`)
+    console.log(`  ${chalk.hex(theme.red)("Requests will be blocked once either limit is depleted.")}`)
+  }
+
+  const allOpusUsage = await prisma.usageEvent.groupBy({
+    by: ["model"],
+    where: {
+      model: OPUS_MODEL_ID,
+      createdAt: { gte: new Date(Date.now() - 30 * 86_400_000) },
+    },
+    _sum: { totalTokens: true },
+    _count: { id: true },
+  })
+
+  if (allOpusUsage.length > 0) {
+    console.log()
+    console.log(sectionHeader("30-Day History", { accent: "green" }))
+    for (const row of allOpusUsage) {
+      const tokens = row._sum.totalTokens ?? 0
+      const calls = row._count.id
+      console.log(`  ${chalk.hex(theme.greenGlow)("Opus 4.8".padEnd(30))} ${formatTokenCount(tokens).padStart(8)}  ${chalk.hex(theme.muted)(`${calls} calls`)}`)
+    }
+  }
+
+  console.log()
+  console.log(heavyDivider())
+  console.log()
+}

--- a/apps/supercode-cli/server/src/index.ts
+++ b/apps/supercode-cli/server/src/index.ts
@@ -33,6 +33,7 @@ const MODEL_MAX_TOKENS: Record<string, number> = {
   "glm-5.2": 4096,
   "glm-5.1": 4096,
   "minimax-m3": 8192,
+  "anthropic/claude-opus-4-8": 4096,
 }
 function getModelMaxTokens(model: string): number {
   const exact = MODEL_MAX_TOKENS[model]

--- a/apps/supercode-cli/server/src/lib/pricing.ts
+++ b/apps/supercode-cli/server/src/lib/pricing.ts
@@ -25,6 +25,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   "z-ai/glm-5.1":             { inputPrice: 0.10,   outputPrice: 0.40,   cachedPrice: 0 },
   "minimax-m3":               { inputPrice: 0.20,   outputPrice: 0.80,   cachedPrice: 0 },
   "meta/llama-3.3-70b-instruct": { inputPrice: 0.59, outputPrice: 0.99, cachedPrice: 0 },
+  "anthropic/claude-opus-4-8": { inputPrice: 5.00, outputPrice: 25.00, cachedPrice: 0.50 },
 }
 
 export function computeCost(model: string, inputTokens: number, outputTokens: number, cachedInputTokens: number): number {

--- a/apps/supercode-cli/server/src/lib/token-budget.ts
+++ b/apps/supercode-cli/server/src/lib/token-budget.ts
@@ -1,0 +1,84 @@
+import { readFile, mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import os from "node:os"
+import { randomUUID } from "node:crypto"
+import prisma from "./prisma"
+
+export const OPUS_MODEL_ID = "anthropic/claude-opus-4-8"
+export const DAILY_BUDGET_TOKENS = 128_000
+export const DAILY_QUERY_LIMIT = 20
+
+const DEVICE_ID_PATH = join(os.homedir(), ".config", "supercode", "device-id")
+
+export async function getOrCreateDeviceId(): Promise<string> {
+  try {
+    const existing = await readFile(DEVICE_ID_PATH, "utf-8")
+    const trimmed = existing.trim()
+    if (trimmed.length > 0) return trimmed
+  } catch {}
+
+  const uuid = randomUUID()
+  await mkdir(join(os.homedir(), ".config", "supercode"), { recursive: true })
+  await writeFile(DEVICE_ID_PATH, uuid, "utf-8")
+  return uuid
+}
+
+function todayStart(): Date {
+  const now = new Date()
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+}
+
+export async function getDailyTokenUsage(model: string): Promise<number> {
+  const result = await prisma.usageEvent.aggregate({
+    _sum: { totalTokens: true },
+    where: {
+      model,
+      createdAt: { gte: todayStart() },
+    },
+  })
+  return result._sum.totalTokens ?? 0
+}
+
+export async function getDailyQueryCount(userId: string): Promise<number> {
+  return prisma.usageEvent.count({
+    where: {
+      model: OPUS_MODEL_ID,
+      userId,
+      createdAt: { gte: todayStart() },
+    },
+  })
+}
+
+export async function checkQueryLimit(userId: string): Promise<{
+  allowed: boolean
+  used: number
+  remaining: number
+  resetTime: string
+}> {
+  const used = await getDailyQueryCount(userId)
+  const remaining = Math.max(0, DAILY_QUERY_LIMIT - used)
+  const tomorrow = new Date(todayStart().getTime() + 86_400_000)
+  return {
+    allowed: remaining > 0,
+    used,
+    remaining,
+    resetTime: tomorrow.toISOString(),
+  }
+}
+
+export async function checkDailyBudget(): Promise<{
+  allowed: boolean
+  used: number
+  remaining: number
+  resetTime: string
+}> {
+  const used = await getDailyTokenUsage(OPUS_MODEL_ID)
+  const remaining = Math.max(0, DAILY_BUDGET_TOKENS - used)
+  const tomorrow = new Date(todayStart().getTime() + 86_400_000)
+  return {
+    allowed: remaining > 0,
+    used,
+    remaining,
+    resetTime: tomorrow.toISOString(),
+  }
+}


### PR DESCRIPTION


## Description


- Add anthropic/claude-opus-4-8 to model selector with 5.0x cost tier
- Configure 500K context window and 4,096 max output tokens
- Add pricing at $5/$25/$0.50 per 1M tokens (input/output/cached)
- Create token-budget.ts with 128K daily budget per device fingerprint
- Integrate budget guard into ConcentrateService with reduced tool budget (5 vs 8)
- Track device identity (UUID) on all usage records
- Add /usage slash command with progress bar and 30-day history
- Tag ConcentrateAI models with FREE badge in model browser

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (if applicable)

## Checklist:

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/usage` command to show current daily limits, usage progress, and recent history.
  * Added a new model option in the CLI model browser with pricing and availability details.

* **Bug Fixes**
  * Improved handling when usage limits are reached, returning a clear message instead of continuing requests.
  * Updated model support settings so the newest model uses the correct token and pricing limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->