### PR TITLE
feat: implement server-side Composio session management and update version to 0.1.61

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercode-cli",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "AI-powered coding agent CLI",
   "main": "dist/main.js",
   "bin": {

--- a/apps/supercode-cli/server/src/cli/commands/ai/init.ts
+++ b/apps/supercode-cli/server/src/cli/commands/ai/init.ts
@@ -54,15 +54,22 @@ export const wakeUpAction = async (resumeId: string | null = null) => {
   const stored = await getCliConfig()
   await applyStoredApiKeys()
 
-  // Auto-restore composio MCP session if previously connected
-  if (composioSessionManager.isConfigured) {
-    try {
-      const info = await composioSessionManager.createSession("supercode-cli")
-      await getMcpManager().start({
-        composio: { url: info.url, headers: info.headers },
-      })
-    } catch {
-      // composio auto-reconnect failed — user can use /mcp to reconnect
+  // Auto-restore composio MCP session — try server-side first, then local SDK
+  try {
+    const info = await composioSessionManager.createSessionFromServer()
+    await getMcpManager().start({
+      composio: { url: info.url, headers: info.headers },
+    })
+  } catch {
+    if (composioSessionManager.isConfigured) {
+      try {
+        const info = await composioSessionManager.createSession("supercode-cli")
+        await getMcpManager().start({
+          composio: { url: info.url, headers: info.headers },
+        })
+      } catch {
+        // composio auto-reconnect failed — user can use /mcp to reconnect
+      }
     }
   }
 

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/mcp.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/mcp.ts
@@ -319,6 +319,25 @@ async function connectFlow(): Promise<void> {
   if (connType === "composio") {
     const mgr = await mcpManager()
 
+    // Try server-side session first (no local API key needed)
+    let sessionErr: Error | null = null
+    try {
+      const info = await composioSessionManager.createSessionFromServer()
+      const config = await getCliConfig()
+      const existing = (config as Record<string, any>) ?? {}
+      await saveCliConfig({
+        ...existing as any,
+        composioSessionId: info.sessionId,
+      } as any)
+      await mgr.reconnectServer("composio", { url: info.url, headers: info.headers })
+      const tools = await mgr.getTools("composio")
+      console.log(`\n ${chalk.hex(theme.green)("◆")} composio connected — ${Object.keys(tools).length} tools`)
+      return
+    } catch (err: any) {
+      sessionErr = err
+    }
+
+    // Fall back to local API key
     if (!composioSessionManager.isConfigured) {
       const apiKey = (await password({
         message: "Composio API key (set COMPOSIO_API_KEY in .env)",
@@ -350,7 +369,10 @@ async function connectFlow(): Promise<void> {
       const tools = await mgr.getTools("composio")
       console.log(`\n ${chalk.hex(theme.green)("◆")} composio connected — ${Object.keys(tools).length} tools`)
     } catch (err: any) {
-      console.log(`\n ${chalk.hex(theme.red)("◆")} composio connection failed: ${err.message}`)
+      const msg = !composioSessionManager.isConfigured
+        ? "Server unreachable and no local API key set"
+        : err.message
+      console.log(`\n ${chalk.hex(theme.red)("◆")} composio connection failed: ${msg}`)
     }
     return
   }
@@ -525,9 +547,20 @@ async function showDetail(entry: ListEntry): Promise<void> {
 
 async function ensureComposioConnected(): Promise<void> {
   if (composioSessionManager.isConnected) return
-  if (!composioSessionManager.isConfigured) return
 
   const mgr = await mcpManager()
+
+  // Try server-side first
+  try {
+    const info = await composioSessionManager.createSessionFromServer()
+    await mgr.reconnectServer("composio", { url: info.url, headers: info.headers })
+    return
+  } catch {
+    // server-side failed, try local SDK
+  }
+
+  if (!composioSessionManager.isConfigured) return
+
   try {
     const info = await composioSessionManager.createSession("supercode-cli")
     await mgr.reconnectServer("composio", { url: info.url, headers: info.headers })

--- a/apps/supercode-cli/server/src/index.ts
+++ b/apps/supercode-cli/server/src/index.ts
@@ -1073,6 +1073,42 @@ app.post("/api/tools/exa-fetch", async (req, res) => {
   }
 })
 
+// ── Composio session proxy (server-side API key) ──
+
+app.post("/api/composio/session", async (req, res) => {
+  try {
+    const user = await getUserFromBearer(req)
+    if (!user) { res.status(401).json({ error: "Unauthorized" }); return }
+
+    const apiKey = process.env.COMPOSIO_API_KEY
+    if (!apiKey) { res.status(500).json({ error: "Composio not configured on server" }); return }
+
+    const { Composio } = await import("@composio/core")
+    const composio = new Composio({ apiKey })
+
+    const connectedRes = await (composio.connectedAccounts as any).list({})
+    const connectedIds: Record<string, string> = {}
+    for (const acct of (connectedRes.items ?? [])) {
+      if (acct.status === "ACTIVE") {
+        connectedIds[acct.toolkit?.slug] = acct.id
+      }
+    }
+
+    const s = await composio.sessions.create(`user_${user.id}`, {
+      mcp: true,
+      connectedAccounts: connectedIds,
+    })
+
+    res.json({
+      url: (s as any).mcp.url as string,
+      headers: (s as any).mcp.headers as Record<string, string>,
+      sessionId: (s as any).session_id as string,
+    })
+  } catch (error: any) {
+    res.status(500).json({ error: error.message || "Composio session creation failed" })
+  }
+})
+
 app.post("/api/tools/web-search", async (req, res) => {
   try {
     const user = await getUserFromBearer(req)

--- a/apps/supercode-cli/server/src/mcp/composio.ts
+++ b/apps/supercode-cli/server/src/mcp/composio.ts
@@ -1,4 +1,7 @@
 import { Composio } from "@composio/core"
+import { getStoredToken } from "src/lib/token"
+
+const BASE_URL = process.env.SUPERCODE_SERVER_URL || "https://supercode-8w7e.onrender.com"
 
 export interface ComposioSessionInfo {
   url: string
@@ -47,6 +50,35 @@ export class ComposioSessionManager {
       throw new Error("COMPOSIO_API_KEY not configured")
     }
     return this.composio
+  }
+
+  async createSessionFromServer(
+    serverUrl = BASE_URL,
+    accessToken?: string,
+  ): Promise<ComposioSessionInfo> {
+    if (!accessToken) {
+      const stored = await getStoredToken()
+      accessToken = stored?.access_token as string
+    }
+    if (!accessToken) {
+      throw new Error("Not authenticated — run supercode login first")
+    }
+
+    const res = await fetch(`${serverUrl}/api/composio/session`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      throw new Error((body as any).error || `Server returned ${res.status}`)
+    }
+
+    const info = (await res.json()) as ComposioSessionInfo
+    this.session = info
+    return info
   }
 
   async createSession(userId = "default"): Promise<ComposioSessionInfo> {


### PR DESCRIPTION


## Description

- Added a new API endpoint for creating Composio sessions on the server.
- Enhanced CLI commands to auto-restore Composio MCP sessions using server-side sessions first, falling back to local SDK if necessary.
- Updated ComposioSessionManager to support server-side session creation.
- Bumped version in package.json to 0.1.61.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (if applicable)

## Checklist:

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-assisted Composio MCP session creation and restoration.
  * CLI connections now automatically reconnect to active Composio accounts and list available tools.
  * Added clearer connection error messages when server access or local credentials are unavailable.

* **Bug Fixes**
  * Improved MCP startup recovery by falling back to local credentials when server-side restoration fails.

* **Chores**
  * Updated the server version to 0.1.61.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->