### PR TITLE
feat: enhance Composio session management and update version to 0.1.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Server-side Composio session proxy — CLI fetches composio MCP session from Render server's env var instead of requiring local `COMPOSIO_API_KEY` in `.env`
+- New `POST /api/composio/session` backend endpoint authenticated via bearer token
+- `createSessionFromServer()` method on `ComposioSessionManager` — fallback chain: server proxy → local SDK → user prompt
+- Paid tier interest check on `init`
+
+### Changed
+
+- CLI `init` auto-restore: tries server-side composio session first before falling back to local SDK
+- `/mcp` interactive flow: tries server-side session before prompting for API key
+- `ensureComposioConnected()` now attempts server-side connection before local SDK
+- Version bumped to 0.1.61
+
+### Fixed
+
+- Composio 401 `Invalid API key` error on init — no longer requires users to manually add API key to `.env`
+
+---
+
+## [0.1.60] — 2026-07-12
+
+### Added
+
+- Scroll-windowing UI for @-picker, slash commands, and model selector
+- AtPicker with fuzzy file search (`at-picker.ts`, `file-search.ts`)
+- Typing animation in `MarkdownStream.renderStyled()` (`markdown-stream.ts`)
+- Allowed models: kimi-k2.6, deepseek-v4-flash, minimax-m3, glm-5.2, glm-5.1, claude-opus-4.8, gpt-5.5
+
+### Changed
+
+- Slash command list uses scroll-windowing (max 10 visible, scroll indicators) in `chat.ts`
+- Model picker uses scroll-windowed inline UI via custom raw-stdin handler (replaced `@clack/prompts` select) in `model.ts`
+- Extended provider/model lists to support redesigned picker
+
+---
+
+## [0.1.53] — 2026-07-10
+
+### Added
+
+- Product Hunt launch banner
+- `/download` page with navbar download button
+- Claude Opus 4.8 integration through ConcentrateAI with daily budget caps
+- ElevenLabs Scribe support with noise-injected transcription handling
+- Exa search/fetch as alternative web search provider
+- Firecrawl tools (search, scrape) proxied through Render server when local API key missing
+- Brand guidelines and contact pages
+- Tool result restructuring and Firecrawl slash commands
+- Code review analysis prompt
+- Non-empty tool results detection
 - LICENSE (MIT) — project is now open source
 - Community health files: CODE_OF_CONDUCT, SECURITY, CONTRIBUTING, SUPPORT
 - GitHub issue templates (bug report + feature request)
@@ -23,3 +72,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README: added CI badges, license link, contributor guide
 - Turbo configuration: added `test` task
 - Root `package.json`: added OSS metadata (description, repository, keywords)
+- Opus 4.8 model provider from Anthropic → ConcentrateAI → Azure

--- a/apps/web/app/(pages)/changelog/page.tsx
+++ b/apps/web/app/(pages)/changelog/page.tsx
@@ -22,15 +22,84 @@ export default function ChangelogPage() {
             <div className="flex items-baseline gap-4 mb-8">
               <h2 className="text-[24px] font-semibold tracking-tight">
                 <a
-                  href="https://github.com/yashdev9274/supercli/releases/tag/v0.1.42"
+                  href="https://github.com/yashdev9274/supercli/releases/tag/v0.1.61"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:text-primary underline underline-offset-4 transition-colors"
                 >
-                  v0.1.42
+                  v0.1.61
                 </a>
               </h2>
-              <span className="text-[14px] text-muted-foreground font-mono">Jul 5, 2026</span>
+              <span className="text-[14px] text-muted-foreground font-mono">Jul 12, 2026</span>
+            </div>
+
+            <div className="space-y-8">
+              <div>
+                <h3 className="text-[17px] text-white font-semibold mb-3 text-muted-foreground uppercase tracking-wider">MCP / Composio</h3>
+                <ul className="space-y-3 text-[14px] leading-relaxed text-foreground/85">
+                  <li>- Server-side Composio session proxy — CLI fetches composio MCP session from server&#39;s Render env instead of requiring a local <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">COMPOSIO_API_KEY</code> in <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">.env</code>.</li>
+                  <li>- New <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">POST /api/composio/session</code> server endpoint creates composio sessions server-side using the Render env var.</li>
+                  <li>- CLI <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">init</code> auto-restore tries server-side composio session first, falls back to local SDK.</li>
+                  <li>- <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">/mcp</code> interactive flow tries server-side session before prompting for API key.</li>
+                  <li>- Fixed Composio 401 <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">Invalid API key</code> on init — users no longer need to manually configure API key in <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">.env</code>.</li>
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-[17px] text-white font-semibold mb-3 text-muted-foreground uppercase tracking-wider">CLI</h3>
+                <ul className="space-y-3 text-[14px] leading-relaxed text-foreground/85">
+                  <li>- Paid tier interest check on <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">init</code>.</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <hr className="border-border" />
+
+          <section>
+            <div className="flex items-baseline gap-4 mb-8">
+              <h2 className="text-[24px] font-semibold tracking-tight">
+                <a
+                  href="https://github.com/yashdev9274/supercli/releases/tag/v0.1.60"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-primary underline underline-offset-4 transition-colors"
+                >
+                  v0.1.60
+                </a>
+              </h2>
+              <span className="text-[14px] text-muted-foreground font-mono">Jul 12, 2026</span>
+            </div>
+
+            <div className="space-y-8">
+              <div>
+                <h3 className="text-[17px] text-white font-semibold mb-3 text-muted-foreground uppercase tracking-wider">CLI / TUI</h3>
+                <ul className="space-y-3 text-[14px] leading-relaxed text-foreground/85">
+                  <li>- Scroll-windowing UI for <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">@</code>-picker, slash commands, and model selector — max 10 visible with scroll indicators.</li>
+                  <li>- New <strong>AtPicker</strong> with fuzzy file search for quick file lookup mid-chat.</li>
+                  <li>- Typing animation in markdown stream rendering for more natural output.</li>
+                  <li>- Model picker rewritten with scroll-windowed inline UI (replaced <code className="text-primary bg-primary/10 px-1.5 py-0.5 rounded text-[13px] font-mono">@clack/prompts</code> select).</li>
+                  <li>- Extended allowed model list: kimi-k2.6, deepseek-v4-flash, minimax-m3, glm-5.2, glm-5.1, claude-opus-4.8, gpt-5.5.</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
+          <hr className="border-border" />
+
+          <section>
+            <div className="flex items-baseline gap-4 mb-8">
+              <h2 className="text-[24px] font-semibold tracking-tight">
+                <a
+                  href="https://github.com/yashdev9274/supercli/releases/tag/v0.1.53"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-primary underline underline-offset-4 transition-colors"
+                >
+                  v0.1.53
+                </a>
+              </h2>
+              <span className="text-[14px] text-muted-foreground font-mono">Jul 10, 2026</span>
             </div>
 
             <div className="space-y-8">

--- a/apps/web/components/homepage/footer.tsx
+++ b/apps/web/components/homepage/footer.tsx
@@ -333,7 +333,7 @@ const Footer = () => {
           </p>
           <div className="flex items-center gap-6">
             <span className="text-[11px] font-mono text-muted-foreground/20">
-              v0.1.42-beta
+              v0.1.61-beta
             </span>
           </div>
         </div>

--- a/apps/web/components/homepage/hero.tsx
+++ b/apps/web/components/homepage/hero.tsx
@@ -45,7 +45,7 @@ const HeroSection = () => {
           {/* Version tag */}
           <div className="flex justify-center mb-4">
             <div className="px-3 py-1 bg-primary/10 text-primary text-[12px] font-mono rounded-md">
-              v0.1.56-beta
+              v0.1.61-beta
             </div>
           </div>
 


### PR DESCRIPTION

## Description

- Implemented server-side Composio session proxy, allowing CLI to fetch sessions from the Render server.
- Added new `POST /api/composio/session` endpoint for server-side session creation.
- Updated CLI `init` to prioritize server-side session restoration over local SDK.
- Fixed Composio 401 error on init, eliminating the need for manual API key configuration.
- Bumped version to 0.1.61 in relevant files.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (if applicable)

## Checklist:

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
