### PR TITLE
feat: bump supercode-cli version to 0.1.88 and add support for Claude Opus 5:

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercode-cli",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "description": "AI-powered coding agent CLI",
   "main": "dist/main.js",
   "bin": {

--- a/apps/supercode-cli/server/src/cli/ai/concentrate-service.ts
+++ b/apps/supercode-cli/server/src/cli/ai/concentrate-service.ts
@@ -6,8 +6,8 @@ import { computeCost } from "../../lib/pricing"
 import { isEmptyToolResult, isDeniedToolResult, summarizeToolResult, tcName } from "./tool-result"
 import { checkDailyOpusLimit, incrementDailyOpusCount } from "../../lib/token-budget"
 
-const HIGH_VALUE_MODELS = ["anthropic/claude-fable-5", "anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7", "openai/gpt-5.5"]
-const OPUS_MODELS = ["anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7"]
+const HIGH_VALUE_MODELS = ["anthropic/claude-fable-5", "anthropic/claude-opus-5", "anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7", "openai/gpt-5.5"]
+const OPUS_MODELS = ["anthropic/claude-opus-5", "anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7"]
 const OPUS_MODEL = "anthropic/claude-opus-4-8"
 
 function getConcentrateApiKey(): string {

--- a/apps/supercode-cli/server/src/cli/ai/context-windows.ts
+++ b/apps/supercode-cli/server/src/cli/ai/context-windows.ts
@@ -18,6 +18,7 @@ const CONTEXT_WINDOWS: Record<string, number> = {
   "glm-5.1": 203_000,
   "minimax-m3": 1_000_000,
   "anthropic/claude-fable-5": 1_000_000,
+  "anthropic/claude-opus-5": 1_000_000,
   "anthropic/claude-opus-4-8": 1_000_000,
   "anthropic/claude-opus-4-7": 1_000_000,
   "openai/gpt-5.5": 1_100_000,

--- a/apps/supercode-cli/server/src/cli/ai/mergedev-service.ts
+++ b/apps/supercode-cli/server/src/cli/ai/mergedev-service.ts
@@ -6,7 +6,7 @@ import { recordUsage } from "../../lib/track-usage"
 import { computeCost } from "../../lib/pricing"
 import { isEmptyToolResult, isDeniedToolResult, summarizeToolResult, tcName } from "./tool-result"
 
-const HIGH_VALUE_MODELS = ["anthropic/claude-fable-5", "anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7", "openai/gpt-5.5"]
+const HIGH_VALUE_MODELS = ["anthropic/claude-fable-5", "anthropic/claude-opus-5", "anthropic/claude-opus-4-8", "anthropic/claude-opus-4-7", "openai/gpt-5.5"]
 
 export class MergeDevService {
   model: LanguageModel

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/model.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/model.ts
@@ -59,6 +59,7 @@ export const CLOUD_MODELS: ModelEntry[] = [
 export const BYOK_MODELS: ModelEntry[] = [
   // ── ConcentrateAI (BYOK) ──────────────────────────────────────
   { value: SECTION_CONCENTRATEAI, label: "ConcentrateAI", provider: "concentrateai", cost: "", desc: "" },
+  { value: "anthropic/claude-opus-5", label: "Claude Opus 5", provider: "concentrateai", cost: "", desc: "Most capable" },
   { value: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8", provider: "concentrateai", cost: "", desc: "Deep reasoning" },
   { value: "anthropic/claude-opus-4", label: "Claude Opus 4", provider: "concentrateai", cost: "", desc: "Top-tier reasoning" },
   { value: "anthropic/claude-sonnet-4-5", label: "Claude Sonnet 4.5", provider: "concentrateai", cost: "", desc: "Latest sonnet" },
@@ -83,6 +84,7 @@ export const BYOK_MODELS: ModelEntry[] = [
 
   // ── Merge Dev Gateway ────────────────────────────────────────
   { value: SECTION_MERGEDEV, label: "Merge Dev Gateway", provider: "mergedev", cost: "", desc: "" },
+  { value: "anthropic/claude-opus-5", label: "Claude Opus 5", provider: "mergedev", cost: "50x", desc: "Most capable" },
   { value: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6", provider: "mergedev", cost: "12x", desc: "Latest sonnet" },
   { value: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8", provider: "mergedev", cost: "40x", desc: "Deep reasoning" },
   { value: "gpt-4o", label: "GPT-4o", provider: "mergedev", cost: "4x", desc: "OpenAI flagship" },
@@ -134,6 +136,7 @@ export const BYOK_MODELS: ModelEntry[] = [
 
   // ── OpenRouter ──────────────────────────────────────────────
   { value: SECTION_OPENROUTER, label: "OpenRouter", provider: "openrouter", cost: "", desc: "" },
+  { value: "anthropic/claude-opus-5", label: "Claude Opus 5", provider: "openrouter", cost: "50x", desc: "Most capable" },
   { value: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8", provider: "openrouter", cost: "40x", desc: "Deep reasoning" },
   { value: "anthropic/claude-opus-4", label: "Claude Opus 4", provider: "openrouter", cost: "30x", desc: "Top-tier reasoning" },
   { value: "anthropic/claude-sonnet-4", label: "Claude Sonnet 4", provider: "openrouter", cost: "12x", desc: "Balanced" },
@@ -171,6 +174,7 @@ export const BYOK_MODELS: ModelEntry[] = [
 
   // ── OrcaRouter ──────────────────────────────────────────────
   { value: SECTION_ORCAROUTER, label: "OrcaRouter", provider: "orcarouter", cost: "", desc: "" },
+  { value: "anthropic/claude-opus-5", label: "Claude Opus 5", provider: "orcarouter", cost: "", desc: "Most capable" },
   { value: "anthropic/claude-opus-4.8", label: "Claude Opus 4.8", provider: "orcarouter", cost: "", desc: "Deep reasoning" },
   { value: "anthropic/claude-opus-4", label: "Claude Opus 4", provider: "orcarouter", cost: "", desc: "Top-tier reasoning" },
   { value: "anthropic/claude-sonnet-4.5", label: "Claude Sonnet 4.5", provider: "orcarouter", cost: "", desc: "Latest sonnet" },

--- a/apps/supercode-cli/server/src/index.ts
+++ b/apps/supercode-cli/server/src/index.ts
@@ -44,6 +44,7 @@ const MODEL_MAX_TOKENS: Record<string, number> = {
   "minimax-m3": 8192,
   "hy3": 8192,
   "anthropic/claude-fable-5": 128000,
+  "anthropic/claude-opus-5": 128000,
   "anthropic/claude-opus-4-7": 128000,
   "anthropic/claude-opus-4-8": 128000,
   "openai/gpt-5.5": 128000,

--- a/apps/supercode-cli/server/src/lib/pricing.ts
+++ b/apps/supercode-cli/server/src/lib/pricing.ts
@@ -26,6 +26,7 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   "minimax-m3":               { inputPrice: 0.20,   outputPrice: 0.80,   cachedPrice: 0 },
   "meta/llama-3.3-70b-instruct": { inputPrice: 0.59, outputPrice: 0.99, cachedPrice: 0 },
   "anthropic/claude-fable-5": { inputPrice: 10.00, outputPrice: 50.00, cachedPrice: 1.00 },
+  "anthropic/claude-opus-5": { inputPrice: 5.00, outputPrice: 25.00, cachedPrice: 0.50 },
   "anthropic/claude-opus-4-8": { inputPrice: 5.00, outputPrice: 25.00, cachedPrice: 0.50 },
   "anthropic/claude-opus-4-7": { inputPrice: 5.00, outputPrice: 25.00, cachedPrice: 0.50 },
   "openai/gpt-5.5":          { inputPrice: 5.00,   outputPrice: 30.00,  cachedPrice: 0.50 },


### PR DESCRIPTION




## Description

- Updated version in package.json to 0.1.88.
- Added "anthropic/claude-opus-5" to high-value models and context windows.
- Included pricing details for "anthropic/claude-opus-5" in the pricing module.
- Updated CLI commands to reflect the addition of "Claude Opus 5" in various contexts.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (if applicable)

## Checklist:

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 5 to the available AI model catalog across supported gateways.
  * Added support for Claude Opus 5’s 1,000,000-token context window and 128,000-token output limit.
  * Added pricing information for Claude Opus 5.
* **Chores**
  * Updated the server package version to 0.1.88.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->