### PR TITLE
feat(cli): add supercode upgrade command

### DIFF
--- a/apps/supercode-cli/server/src/cli/commands/ai/init.ts
+++ b/apps/supercode-cli/server/src/cli/commands/ai/init.ts
@@ -11,7 +11,6 @@ import { createThinking, errorBox } from "src/cli/utils/tui"
 import { renderWelcome } from "src/cli/utils/welcome"
 import { scanWorkspace } from "src/cli/workspace/scanner.ts"
 import { getCliConfig, saveCliConfig, applyStoredApiKeys } from "src/lib/cli-config"
-import { checkForUpdate } from "src/cli/utils/auto-update"
 import { checkPaidTierInterest } from "src/cli/utils/paid-tier-check"
 import { CLOUD_MODELS } from "src/cli/commands/slashCommands/model"
 
@@ -41,7 +40,6 @@ export const wakeUpAction = async (resumeId: string | null = null) => {
   const user = result.user
   thinking.succeed(`Welcome, ${user.name}`)
 
-  await checkForUpdate()
   await checkPaidTierInterest()
 
   const wsThinking = createThinking("scanning workspace")

--- a/apps/supercode-cli/server/src/cli/commands/upgrade.ts
+++ b/apps/supercode-cli/server/src/cli/commands/upgrade.ts
@@ -3,9 +3,7 @@ import chalk from "chalk"
 import { confirm, isCancel } from "@clack/prompts"
 import { version as currentVersion } from "../../../package.json"
 import { theme, createThinking } from "../utils/tui"
-import { compareVersions, fetchLatestVersion } from "../utils/version"
-
-const NPM_PACKAGE = "supercode-cli"
+import { compareVersions, fetchLatestVersion, NPM_PACKAGE } from "../utils/version"
 
 export async function upgradeAction(options: { yes?: boolean }): Promise<void> {
 

--- a/apps/supercode-cli/server/src/cli/commands/upgrade.ts
+++ b/apps/supercode-cli/server/src/cli/commands/upgrade.ts
@@ -36,6 +36,14 @@ export async function upgradeAction(options: { yes?: boolean }): Promise<void> {
     process.exit(1)
   }
 
+  if (cmp === 1) {
+    thinking.succeed(`v${currentVersion} (newer than npm's v${latestVersion})`)
+    console.log()
+    console.log(`  ${chalk.hex(theme.green)("◆")} ${chalk.hex(theme.greenMute)("You're on a pre-release or local build — no upgrade needed.")}`)
+    console.log()
+    return
+  }
+
   // currentVersion < latestVersion
   thinking.stop()
   console.log()

--- a/apps/supercode-cli/server/src/cli/commands/upgrade.ts
+++ b/apps/supercode-cli/server/src/cli/commands/upgrade.ts
@@ -1,10 +1,11 @@
-import { execSync } from "child_process"
+import { execFileSync } from "child_process"
 import { Command } from "commander"
 import chalk from "chalk"
 import { confirm, isCancel } from "@clack/prompts"
 import { version as currentVersion } from "../../../package.json"
 import { theme, createThinking } from "../utils/tui"
 import { compareVersions, fetchLatestVersion, NPM_PACKAGE } from "../utils/version"
+import { saveCliConfig } from "src/lib/cli-config"
 
 export async function upgradeAction(options: { yes?: boolean }): Promise<void> {
 
@@ -67,7 +68,8 @@ export async function upgradeAction(options: { yes?: boolean }): Promise<void> {
   const spinner = createThinking("upgrading supercode")
 
   try {
-    execSync(`bun install -g ${NPM_PACKAGE}@latest`, { stdio: "pipe" })
+    execFileSync("bun", ["install", "-g", `${NPM_PACKAGE}@latest`], { stdio: "pipe" })
+    await saveCliConfig({ checkForUpdates: true })
     spinner.succeed(`Updated to v${latestVersion}`)
     console.log()
     console.log(`  ${chalk.hex(theme.green)("◆")} ${chalk.hex(theme.greenMute)("Run")} ${chalk.hex(theme.greenGlow)("supercode --version")} ${chalk.hex(theme.greenMute)("to confirm.")}`)

--- a/apps/supercode-cli/server/src/cli/commands/upgrade.ts
+++ b/apps/supercode-cli/server/src/cli/commands/upgrade.ts
@@ -1,0 +1,86 @@
+import { Command } from "commander"
+import chalk from "chalk"
+import { confirm, isCancel } from "@clack/prompts"
+import { version as currentVersion } from "../../../package.json"
+import { theme, createThinking } from "../utils/tui"
+import { compareVersions, fetchLatestVersion } from "../utils/version"
+
+const NPM_PACKAGE = "supercode-cli"
+
+export async function upgradeAction(options: { yes?: boolean }): Promise<void> {
+
+  const thinking = createThinking("checking npm registry")
+
+  const latestVersion = await fetchLatestVersion(NPM_PACKAGE)
+
+  if (!latestVersion) {
+    thinking.fail("Could not reach npm registry")
+    console.log()
+    console.log(`  ${chalk.hex(theme.muted)("Check your internet connection and try again.")}`)
+    console.log()
+    process.exit(1)
+  }
+
+  const cmp = compareVersions(currentVersion, latestVersion)
+
+  if (cmp === 0) {
+    thinking.succeed(`v${currentVersion} (latest)`)
+    console.log()
+    console.log(`  ${chalk.hex(theme.green)("◆")} ${chalk.hex(theme.greenMute)("You're on the latest version.")}`)
+    console.log()
+    return
+  }
+
+  if (cmp === null) {
+    thinking.fail(`Could not compare versions: ${currentVersion} vs ${latestVersion}`)
+    process.exit(1)
+  }
+
+  // currentVersion < latestVersion
+  thinking.stop()
+  console.log()
+  console.log(
+    `  ${chalk.hex(theme.amber)("◆")}  ${chalk.hex(theme.green).bold("Update available:")} ${chalk.hex(theme.greenDim)(`v${currentVersion}`)} → ${chalk.hex(theme.greenGlow)(`v${latestVersion}`)}`,
+  )
+  console.log()
+
+  if (!options.yes) {
+    const shouldUpdate = await confirm({
+      message: "Update to latest version?",
+      initialValue: true,
+    })
+
+    if (isCancel(shouldUpdate) || !shouldUpdate) {
+      console.log(`  ${chalk.hex(theme.greenMute)("Skipping update")}`)
+      console.log()
+      return
+    }
+  }
+
+  const spinner = createThinking("upgrading supercode")
+
+  try {
+    const result = await Bun.$`bun install -g ${NPM_PACKAGE}@latest`.quiet()
+    if (result.exitCode === 0) {
+      spinner.succeed(`Updated to v${latestVersion}`)
+      console.log()
+      console.log(`  ${chalk.hex(theme.green)("◆")} ${chalk.hex(theme.greenMute)("Run")} ${chalk.hex(theme.greenGlow)("supercode --version")} ${chalk.hex(theme.greenMute)("to confirm.")}`)
+      console.log()
+    } else {
+      throw new Error(`exit code ${result.exitCode}`)
+    }
+  } catch {
+    spinner.fail("Upgrade failed")
+    console.log(`  ${chalk.hex(theme.greenMute)("Try running manually:")}`)
+    console.log(`  ${chalk.hex(theme.greenGlow)("bun install -g")} ${chalk.hex(theme.greenDim)(`${NPM_PACKAGE}@latest`)}`)
+    console.log()
+    process.exit(1)
+  }
+}
+
+export const upgradeCommand = new Command("upgrade")
+  .description("Check for updates and upgrade the CLI to the latest version")
+  .option("-y, --yes", "Skip confirmation prompt and upgrade immediately")
+  .action(async (opts: { yes?: boolean }) => {
+    await upgradeAction({ yes: opts.yes })
+  })

--- a/apps/supercode-cli/server/src/cli/commands/upgrade.ts
+++ b/apps/supercode-cli/server/src/cli/commands/upgrade.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process"
 import { Command } from "commander"
 import chalk from "chalk"
 import { confirm, isCancel } from "@clack/prompts"
@@ -66,19 +67,16 @@ export async function upgradeAction(options: { yes?: boolean }): Promise<void> {
   const spinner = createThinking("upgrading supercode")
 
   try {
-    const result = await Bun.$`bun install -g ${NPM_PACKAGE}@latest`.quiet()
-    if (result.exitCode === 0) {
-      spinner.succeed(`Updated to v${latestVersion}`)
-      console.log()
-      console.log(`  ${chalk.hex(theme.green)("◆")} ${chalk.hex(theme.greenMute)("Run")} ${chalk.hex(theme.greenGlow)("supercode --version")} ${chalk.hex(theme.greenMute)("to confirm.")}`)
-      console.log()
-    } else {
-      throw new Error(`exit code ${result.exitCode}`)
-    }
+    execSync(`bun install -g ${NPM_PACKAGE}@latest`, { stdio: "pipe" })
+    spinner.succeed(`Updated to v${latestVersion}`)
+    console.log()
+    console.log(`  ${chalk.hex(theme.green)("◆")} ${chalk.hex(theme.greenMute)("Run")} ${chalk.hex(theme.greenGlow)("supercode --version")} ${chalk.hex(theme.greenMute)("to confirm.")}`)
+    console.log()
   } catch {
     spinner.fail("Upgrade failed")
     console.log(`  ${chalk.hex(theme.greenMute)("Try running manually:")}`)
     console.log(`  ${chalk.hex(theme.greenGlow)("bun install -g")} ${chalk.hex(theme.greenDim)(`${NPM_PACKAGE}@latest`)}`)
+    console.log(`  ${chalk.hex(theme.greenGlow)("npm install -g")} ${chalk.hex(theme.greenDim)(`${NPM_PACKAGE}@latest`)}`)
     console.log()
     process.exit(1)
   }

--- a/apps/supercode-cli/server/src/cli/main.ts
+++ b/apps/supercode-cli/server/src/cli/main.ts
@@ -11,7 +11,7 @@ import { supercodeInit } from "./commands/ai/init"
 import { skillCommand } from "./commands/skill"
 import { renderWelcome } from "./utils/welcome"
 import { checkForUpdate } from "./utils/auto-update"
-import { getCliConfig } from "src/lib/cli-config"
+import { getCheckForUpdatesSetting } from "src/lib/cli-config"
 
 process.on("unhandledRejection", (reason) => {
   try {
@@ -42,8 +42,7 @@ async function main() {
     renderWelcome(version)
 
     // Opt-in startup version-check notification (disabled by default)
-    const config = await getCliConfig()
-    if (config?.checkForUpdates) {
+    if (await getCheckForUpdatesSetting()) {
       await checkForUpdate()
     }
 

--- a/apps/supercode-cli/server/src/cli/main.ts
+++ b/apps/supercode-cli/server/src/cli/main.ts
@@ -5,10 +5,13 @@ import { version } from "../../package.json"
 import chalk from "chalk"
 import { Command } from "commander"
 import { loginCommand } from "./commands/login"
+import { upgradeCommand } from "./commands/upgrade"
 import { theme } from "./utils/tui"
 import { supercodeInit } from "./commands/ai/init"
 import { skillCommand } from "./commands/skill"
 import { renderWelcome } from "./utils/welcome"
+import { checkForUpdate } from "./utils/auto-update"
+import { getCliConfig } from "src/lib/cli-config"
 
 process.on("unhandledRejection", (reason) => {
   try {
@@ -33,9 +36,17 @@ async function main() {
     .addCommand(loginCommand)
     .addCommand(supercodeInit)
     .addCommand(skillCommand)
+    .addCommand(upgradeCommand)
 
   program.action(async () => {
     renderWelcome(version)
+
+    // Opt-in startup version-check notification (disabled by default)
+    const config = await getCliConfig()
+    if (config?.checkForUpdates) {
+      await checkForUpdate()
+    }
+
     program.help()
   })
 

--- a/apps/supercode-cli/server/src/cli/utils/auto-update.ts
+++ b/apps/supercode-cli/server/src/cli/utils/auto-update.ts
@@ -1,5 +1,6 @@
 import { version } from "../../../package.json"
 import chalk from "chalk"
+import { compareVersions } from "./version"
 import { theme, createThinking } from "./tui"
 
 const NPM_PACKAGE = "supercode-cli"
@@ -26,8 +27,17 @@ export async function checkForUpdate(): Promise<void> {
     }
     const latest = data.version
 
-    if (latest === version) {
+    const cmp = compareVersions(version, latest)
+    if (cmp === 0) {
       thinking.succeed(`v${version} (latest)`)
+      return
+    }
+    if (cmp === 1) {
+      thinking.succeed(`v${version} (ahead of npm)`)
+      return
+    }
+    if (cmp === null) {
+      thinking.fail("could not compare versions")
       return
     }
 

--- a/apps/supercode-cli/server/src/cli/utils/auto-update.ts
+++ b/apps/supercode-cli/server/src/cli/utils/auto-update.ts
@@ -1,10 +1,14 @@
 import { version } from "../../../package.json"
 import chalk from "chalk"
 import { theme, createThinking } from "./tui"
-import { confirm, isCancel } from "@clack/prompts"
 
 const NPM_PACKAGE = "supercode-cli"
 
+/**
+ * Check npm registry for a newer version and print a banner if one exists.
+ * Notification-only — never prompts or installs.
+ * Users should run `supercode upgrade` to actually install.
+ */
 export async function checkForUpdate(): Promise<void> {
   const thinking = createThinking("checking for update")
   try {
@@ -15,7 +19,11 @@ export async function checkForUpdate(): Promise<void> {
       thinking.fail("could not reach registry")
       return
     }
-    const data = (await res.json()) as { version: string }
+    const data = (await res.json()) as { version?: unknown }
+    if (typeof data.version !== "string" || data.version.length === 0) {
+      thinking.fail("invalid registry response")
+      return
+    }
     const latest = data.version
 
     if (latest === version) {
@@ -28,33 +36,10 @@ export async function checkForUpdate(): Promise<void> {
     console.log(
       `  ${chalk.hex(theme.amber)("◆")}  ${chalk.hex(theme.green).bold("Update available:")} ${chalk.hex(theme.greenDim)(`v${version}`)} → ${chalk.hex(theme.greenGlow)(`v${latest}`)}`,
     )
+    console.log(
+      `  ${chalk.hex(theme.greenMute)("Run")} ${chalk.hex(theme.greenGlow)("supercode upgrade")} ${chalk.hex(theme.greenMute)("to update.")}`,
+    )
     console.log()
-
-    const shouldUpdate = await confirm({
-      message: "Update to latest version?",
-      initialValue: true,
-    })
-
-    if (isCancel(shouldUpdate) || !shouldUpdate) {
-      console.log(`  ${chalk.hex(theme.greenMute)("Skipping update")}`)
-      console.log()
-      return
-    }
-
-    const spinner = createThinking("updating supercode")
-    try {
-      const result = await Bun.$`npm install -g ${NPM_PACKAGE}@latest`.quiet()
-      if (result.exitCode === 0) {
-        spinner.succeed(`Updated to v${latest}`)
-        console.log()
-      } else {
-        throw new Error(`exit code ${result.exitCode}`)
-      }
-    } catch {
-      spinner.fail("Update failed")
-      console.log(`  ${chalk.hex(theme.greenMute)("Continuing with current version")}`)
-      console.log()
-    }
   } catch {
     thinking.fail("update check failed")
   }

--- a/apps/supercode-cli/server/src/cli/utils/auto-update.ts
+++ b/apps/supercode-cli/server/src/cli/utils/auto-update.ts
@@ -1,9 +1,7 @@
 import { version } from "../../../package.json"
 import chalk from "chalk"
-import { compareVersions } from "./version"
+import { compareVersions, fetchLatestVersion, NPM_PACKAGE } from "./version"
 import { theme, createThinking } from "./tui"
-
-const NPM_PACKAGE = "supercode-cli"
 
 /**
  * Check npm registry for a newer version and print a banner if one exists.
@@ -12,45 +10,34 @@ const NPM_PACKAGE = "supercode-cli"
  */
 export async function checkForUpdate(): Promise<void> {
   const thinking = createThinking("checking for update")
-  try {
-    const res = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE}/latest`, {
-      signal: AbortSignal.timeout(5000),
-    })
-    if (!res.ok) {
-      thinking.fail("could not reach registry")
-      return
-    }
-    const data = (await res.json()) as { version?: unknown }
-    if (typeof data.version !== "string" || data.version.length === 0) {
-      thinking.fail("invalid registry response")
-      return
-    }
-    const latest = data.version
 
-    const cmp = compareVersions(version, latest)
-    if (cmp === 0) {
-      thinking.succeed(`v${version} (latest)`)
-      return
-    }
-    if (cmp === 1) {
-      thinking.succeed(`v${version} (ahead of npm)`)
-      return
-    }
-    if (cmp === null) {
-      thinking.fail("could not compare versions")
-      return
-    }
-
-    thinking.stop()
-    console.log()
-    console.log(
-      `  ${chalk.hex(theme.amber)("◆")}  ${chalk.hex(theme.green).bold("Update available:")} ${chalk.hex(theme.greenDim)(`v${version}`)} → ${chalk.hex(theme.greenGlow)(`v${latest}`)}`,
-    )
-    console.log(
-      `  ${chalk.hex(theme.greenMute)("Run")} ${chalk.hex(theme.greenGlow)("supercode upgrade")} ${chalk.hex(theme.greenMute)("to update.")}`,
-    )
-    console.log()
-  } catch {
-    thinking.fail("update check failed")
+  const latest = await fetchLatestVersion(NPM_PACKAGE)
+  if (!latest) {
+    thinking.fail("could not reach registry")
+    return
   }
+
+  const cmp = compareVersions(version, latest)
+  if (cmp === 0) {
+    thinking.succeed(`v${version} (latest)`)
+    return
+  }
+  if (cmp === 1) {
+    thinking.succeed(`v${version} (ahead of npm)`)
+    return
+  }
+  if (cmp === null) {
+    thinking.fail("could not compare versions")
+    return
+  }
+
+  thinking.stop()
+  console.log()
+  console.log(
+    `  ${chalk.hex(theme.amber)("◆")}  ${chalk.hex(theme.green).bold("Update available:")} ${chalk.hex(theme.greenDim)(`v${version}`)} → ${chalk.hex(theme.greenGlow)(`v${latest}`)}`,
+  )
+  console.log(
+    `  ${chalk.hex(theme.greenMute)("Run")} ${chalk.hex(theme.greenGlow)("supercode upgrade")} ${chalk.hex(theme.greenMute)("to update.")}`,
+  )
+  console.log()
 }

--- a/apps/supercode-cli/server/src/cli/utils/version.test.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.test.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "bun:test"
+import { compareVersions } from "./version"
+
+test("compareVersions returns 0 for equal versions", () => {
+  expect(compareVersions("0.1.0", "0.1.0")).toBe(0)
+  expect(compareVersions("1.0.0", "1.0.0")).toBe(0)
+  expect(compareVersions("0.1.90", "0.1.90")).toBe(0)
+})
+
+test("compareVersions returns -1 when first is older", () => {
+  expect(compareVersions("0.1.0", "0.2.0")).toBe(-1)
+  expect(compareVersions("1.0.0", "1.1.0")).toBe(-1)
+  expect(compareVersions("0.1.89", "0.1.90")).toBe(-1)
+  expect(compareVersions("0.1.90", "0.2.0")).toBe(-1)
+  expect(compareVersions("2.0.0", "10.0.0")).toBe(-1)
+})
+
+test("compareVersions returns 1 when first is newer", () => {
+  expect(compareVersions("0.2.0", "0.1.0")).toBe(1)
+  expect(compareVersions("1.1.0", "1.0.0")).toBe(1)
+  expect(compareVersions("0.1.90", "0.1.89")).toBe(1)
+  expect(compareVersions("0.2.0", "0.1.90")).toBe(1)
+  expect(compareVersions("10.0.0", "2.0.0")).toBe(1)
+})
+
+test("compareVersions handles versions with v prefix", () => {
+  expect(compareVersions("v0.1.0", "0.1.0")).toBe(0)
+  expect(compareVersions("v1.0.0", "1.0.0")).toBe(0)
+})
+
+test("compareVersions handles different length versions", () => {
+  expect(compareVersions("1.0", "1.0.0")).toBe(0)
+  expect(compareVersions("1.0", "1.0.1")).toBe(-1)
+  expect(compareVersions("1.0.1", "1.0")).toBe(1)
+})
+
+test("compareVersions returns null for invalid versions", () => {
+  expect(compareVersions("invalid", "1.0.0")).toBeNull()
+  expect(compareVersions("1.0.0", "invalid")).toBeNull()
+  expect(compareVersions("", "1.0.0")).toBeNull()
+  expect(compareVersions("1.0.0", "")).toBeNull()
+})

--- a/apps/supercode-cli/server/src/cli/utils/version.test.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.test.ts
@@ -61,6 +61,12 @@ test("compareVersions orders prerelease numeric identifiers correctly", () => {
   expect(compareVersions("1.0.0-alpha.1", "1.0.0-alpha.1")).toBe(0)
 })
 
+test("compareVersions treats non-numeric prerelease identifiers correctly", () => {
+  // "1a" is non-numeric, "2" is numeric; per semver, numeric < string
+  expect(compareVersions("1.0.0-alpha.1a", "1.0.0-alpha.2")).toBe(1)
+  expect(compareVersions("1.0.0-alpha.2", "1.0.0-alpha.1a")).toBe(-1)
+})
+
 test("compareVersions handles build metadata gracefully", () => {
   expect(compareVersions("1.0.0+build123", "1.0.0")).toBe(0)
   expect(compareVersions("1.0.0", "1.0.0+build123")).toBe(0)

--- a/apps/supercode-cli/server/src/cli/utils/version.test.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, mock } from "bun:test"
+import { test, expect, mock, describe, beforeEach, afterEach } from "bun:test"
 import { compareVersions, fetchLatestVersion } from "./version"
 
 test("compareVersions returns 0 for equal versions", () => {
@@ -78,36 +78,40 @@ test("compareVersions handles build metadata gracefully", () => {
   expect(compareVersions("1.0.0", "1.0.0+build123")).toBe(0)
 })
 
-test("fetchLatestVersion returns version string on success", async () => {
-  const orig = globalThis.fetch
-  globalThis.fetch = mock(() =>
-    Promise.resolve(new Response(JSON.stringify({ version: "1.2.3" }))),
-  ) as unknown as typeof fetch
-  expect(await fetchLatestVersion("test-pkg")).toBe("1.2.3")
-  globalThis.fetch = orig
-})
+describe("fetchLatestVersion", () => {
+  let origFetch: typeof fetch
 
-test("fetchLatestVersion returns null on non-ok response", async () => {
-  const orig = globalThis.fetch
-  globalThis.fetch = mock(() =>
-    Promise.resolve(new Response(null, { status: 404 })),
-  ) as unknown as typeof fetch
-  expect(await fetchLatestVersion("test-pkg")).toBeNull()
-  globalThis.fetch = orig
-})
+  beforeEach(() => {
+    origFetch = globalThis.fetch
+  })
 
-test("fetchLatestVersion returns null on malformed json response", async () => {
-  const orig = globalThis.fetch
-  globalThis.fetch = mock(() =>
-    Promise.resolve(new Response(JSON.stringify({}))),
-  ) as unknown as typeof fetch
-  expect(await fetchLatestVersion("test-pkg")).toBeNull()
-  globalThis.fetch = orig
-})
+  afterEach(() => {
+    globalThis.fetch = origFetch
+  })
 
-test("fetchLatestVersion returns null on network error", async () => {
-  const orig = globalThis.fetch
-  globalThis.fetch = mock(() => Promise.reject(new Error("network error"))) as unknown as typeof fetch
-  expect(await fetchLatestVersion("test-pkg")).toBeNull()
-  globalThis.fetch = orig
+  test("returns version string on success", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ version: "1.2.3" }))),
+    ) as unknown as typeof fetch
+    expect(await fetchLatestVersion("test-pkg")).toBe("1.2.3")
+  })
+
+  test("returns null on non-ok response", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(null, { status: 404 })),
+    ) as unknown as typeof fetch
+    expect(await fetchLatestVersion("test-pkg")).toBeNull()
+  })
+
+  test("returns null on malformed json response", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({}))),
+    ) as unknown as typeof fetch
+    expect(await fetchLatestVersion("test-pkg")).toBeNull()
+  })
+
+  test("returns null on network error", async () => {
+    globalThis.fetch = mock(() => Promise.reject(new Error("network error"))) as unknown as typeof fetch
+    expect(await fetchLatestVersion("test-pkg")).toBeNull()
+  })
 })

--- a/apps/supercode-cli/server/src/cli/utils/version.test.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test"
-import { compareVersions } from "./version"
+import { test, expect, mock } from "bun:test"
+import { compareVersions, fetchLatestVersion } from "./version"
 
 test("compareVersions returns 0 for equal versions", () => {
   expect(compareVersions("0.1.0", "0.1.0")).toBe(0)
@@ -67,7 +67,47 @@ test("compareVersions treats non-numeric prerelease identifiers correctly", () =
   expect(compareVersions("1.0.0-alpha.2", "1.0.0-alpha.1a")).toBe(-1)
 })
 
+test("compareVersions handles variable-length prerelease identifiers", () => {
+  // More prerelease fields = higher precedence per semver spec
+  expect(compareVersions("1.0.0-alpha", "1.0.0-alpha.1")).toBe(-1)
+  expect(compareVersions("1.0.0-alpha.1", "1.0.0-alpha")).toBe(1)
+})
+
 test("compareVersions handles build metadata gracefully", () => {
   expect(compareVersions("1.0.0+build123", "1.0.0")).toBe(0)
   expect(compareVersions("1.0.0", "1.0.0+build123")).toBe(0)
+})
+
+test("fetchLatestVersion returns version string on success", async () => {
+  const orig = globalThis.fetch
+  globalThis.fetch = mock(() =>
+    Promise.resolve(new Response(JSON.stringify({ version: "1.2.3" }))),
+  ) as unknown as typeof fetch
+  expect(await fetchLatestVersion("test-pkg")).toBe("1.2.3")
+  globalThis.fetch = orig
+})
+
+test("fetchLatestVersion returns null on non-ok response", async () => {
+  const orig = globalThis.fetch
+  globalThis.fetch = mock(() =>
+    Promise.resolve(new Response(null, { status: 404 })),
+  ) as unknown as typeof fetch
+  expect(await fetchLatestVersion("test-pkg")).toBeNull()
+  globalThis.fetch = orig
+})
+
+test("fetchLatestVersion returns null on malformed json response", async () => {
+  const orig = globalThis.fetch
+  globalThis.fetch = mock(() =>
+    Promise.resolve(new Response(JSON.stringify({}))),
+  ) as unknown as typeof fetch
+  expect(await fetchLatestVersion("test-pkg")).toBeNull()
+  globalThis.fetch = orig
+})
+
+test("fetchLatestVersion returns null on network error", async () => {
+  const orig = globalThis.fetch
+  globalThis.fetch = mock(() => Promise.reject(new Error("network error"))) as unknown as typeof fetch
+  expect(await fetchLatestVersion("test-pkg")).toBeNull()
+  globalThis.fetch = orig
 })

--- a/apps/supercode-cli/server/src/cli/utils/version.test.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.test.ts
@@ -40,3 +40,28 @@ test("compareVersions returns null for invalid versions", () => {
   expect(compareVersions("", "1.0.0")).toBeNull()
   expect(compareVersions("1.0.0", "")).toBeNull()
 })
+
+test("compareVersions rejects malformed semver suffixes", () => {
+  expect(compareVersions("1.2.3foo", "1.2.3")).toBeNull()
+  expect(compareVersions("1.2.3", "1.2.3foo")).toBeNull()
+  expect(compareVersions("1.2.3.", "1.2.3")).toBeNull()
+  expect(compareVersions("1.2.3.", "1.2.3")).toBeNull()
+})
+
+test("compareVersions orders prereleases below stable", () => {
+  expect(compareVersions("1.0.0-alpha", "1.0.0")).toBe(-1)
+  expect(compareVersions("1.0.0", "1.0.0-alpha")).toBe(1)
+  expect(compareVersions("1.0.0-alpha", "1.0.0-beta")).toBe(-1)
+  expect(compareVersions("1.0.0-beta", "1.0.0-alpha")).toBe(1)
+})
+
+test("compareVersions orders prerelease numeric identifiers correctly", () => {
+  expect(compareVersions("1.0.0-alpha.1", "1.0.0-alpha.2")).toBe(-1)
+  expect(compareVersions("1.0.0-alpha.2", "1.0.0-alpha.1")).toBe(1)
+  expect(compareVersions("1.0.0-alpha.1", "1.0.0-alpha.1")).toBe(0)
+})
+
+test("compareVersions handles build metadata gracefully", () => {
+  expect(compareVersions("1.0.0+build123", "1.0.0")).toBe(0)
+  expect(compareVersions("1.0.0", "1.0.0+build123")).toBe(0)
+})

--- a/apps/supercode-cli/server/src/cli/utils/version.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.ts
@@ -3,17 +3,71 @@ const NPM_REGISTRY = "https://registry.npmjs.org"
 const NPM_PACKAGE_NAME = "supercode-cli"
 
 /**
- * Parse a semver string into its numeric parts.
+ * Valid semver pattern: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
+ * Handles v prefix, partial versions like "1.0" (missing parts → 0),
+ * and rejects malformed suffixes like "1.2.3foo".
+ */
+const SEMVER_RE = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/
+
+interface ParsedVersion {
+  major: number
+  minor: number
+  patch: number
+  prerelease: string | null
+}
+
+/**
+ * Parse a semver string into its components.
  * Returns null for invalid versions.
  */
-function parseSemver(v: string): number[] | null {
-  const parts = v.replace(/^v/, "").split(".")
-  const nums = parts.map((p) => {
-    const n = parseInt(p, 10)
-    return isNaN(n) ? -1 : n
-  })
-  if (nums.some((n) => n < 0) || nums.length === 0) return null
-  return nums
+function parseSemver(v: string): ParsedVersion | null {
+  const match = v.match(SEMVER_RE)
+  if (!match) return null
+  const major = parseInt(match[1]!, 10)
+  const minor = match[2] ? parseInt(match[2], 10) : 0
+  const patch = match[3] ? parseInt(match[3], 10) : 0
+  const prerelease = match[4] ?? null
+  return { major, minor, patch, prerelease }
+}
+
+/**
+ * Compare two prerelease identifiers per semver spec:
+ * - No prerelease > with prerelease (stable wins)
+ * - Split on ".", compare field by field
+ * - Numeric fields compare numerically, string fields lexicographically
+ * - Numeric < string
+ */
+function comparePrerelease(a: string | null, b: string | null): number {
+  if (a === null && b === null) return 0
+  if (a === null) return 1   // stable > prerelease
+  if (b === null) return -1  // prerelease < stable
+
+  const aParts = a.split(".")
+  const bParts = b.split(".")
+  const len = Math.max(aParts.length, bParts.length)
+
+  for (let i = 0; i < len; i++) {
+    const ap = aParts[i]
+    const bp = bParts[i]
+    if (ap === undefined) return -1
+    if (bp === undefined) return 1
+
+    const aNum = parseInt(ap, 10)
+    const bNum = parseInt(bp, 10)
+    const aIsNum = !isNaN(aNum)
+    const bIsNum = !isNaN(bNum)
+
+    if (aIsNum && bIsNum) {
+      if (aNum !== bNum) return aNum < bNum ? -1 : 1
+    } else if (aIsNum) {
+      return -1 // numeric < string
+    } else if (bIsNum) {
+      return 1  // string > numeric
+    } else if (ap !== bp) {
+      return ap < bp ? -1 : 1
+    }
+  }
+  return 0
 }
 
 /**
@@ -26,19 +80,18 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 | null {
   const pb = parseSemver(b)
   if (!pa || !pb) return null
 
-  const len = Math.max(pa.length, pb.length)
-  for (let i = 0; i < len; i++) {
-    const na = pa[i] ?? 0
-    const nb = pb[i] ?? 0
-    if (na < nb) return -1
-    if (na > nb) return 1
-  }
+  if (pa.major !== pb.major) return pa.major < pb.major ? -1 : 1
+  if (pa.minor !== pb.minor) return pa.minor < pb.minor ? -1 : 1
+  if (pa.patch !== pb.patch) return pa.patch < pb.patch ? -1 : 1
+
+  const pc = comparePrerelease(pa.prerelease, pb.prerelease)
+  if (pc !== 0) return pc < 0 ? -1 : 1
   return 0
 }
 
 /**
  * Fetch the latest published version from npm registry.
- * Returns null on failure.
+ * Returns null on failure or if the response is malformed.
  */
 export async function fetchLatestVersion(
   packageName: string = NPM_PACKAGE_NAME,
@@ -48,8 +101,9 @@ export async function fetchLatestVersion(
       signal: AbortSignal.timeout(5000),
     })
     if (!res.ok) return null
-    const data = (await res.json()) as { version: string }
-    return data.version ?? null
+    const data = (await res.json()) as { version?: unknown }
+    if (typeof data.version !== "string" || data.version.length === 0) return null
+    return data.version
   } catch {
     return null
   }

--- a/apps/supercode-cli/server/src/cli/utils/version.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.ts
@@ -1,0 +1,56 @@
+const NPM_REGISTRY = "https://registry.npmjs.org"
+
+const NPM_PACKAGE_NAME = "supercode-cli"
+
+/**
+ * Parse a semver string into its numeric parts.
+ * Returns null for invalid versions.
+ */
+function parseSemver(v: string): number[] | null {
+  const parts = v.replace(/^v/, "").split(".")
+  const nums = parts.map((p) => {
+    const n = parseInt(p, 10)
+    return isNaN(n) ? -1 : n
+  })
+  if (nums.some((n) => n < 0) || nums.length === 0) return null
+  return nums
+}
+
+/**
+ * Compare two semver strings.
+ * Returns -1 if a < b, 0 if a === b, 1 if a > b.
+ * Returns null if either version is unparseable.
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 | null {
+  const pa = parseSemver(a)
+  const pb = parseSemver(b)
+  if (!pa || !pb) return null
+
+  const len = Math.max(pa.length, pb.length)
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0
+    const nb = pb[i] ?? 0
+    if (na < nb) return -1
+    if (na > nb) return 1
+  }
+  return 0
+}
+
+/**
+ * Fetch the latest published version from npm registry.
+ * Returns null on failure.
+ */
+export async function fetchLatestVersion(
+  packageName: string = NPM_PACKAGE_NAME,
+): Promise<string | null> {
+  try {
+    const res = await fetch(`${NPM_REGISTRY}/${packageName}/latest`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as { version: string }
+    return data.version ?? null
+  } catch {
+    return null
+  }
+}

--- a/apps/supercode-cli/server/src/cli/utils/version.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.ts
@@ -1,6 +1,6 @@
 const NPM_REGISTRY = "https://registry.npmjs.org"
 
-const NPM_PACKAGE_NAME = "supercode-cli"
+export const NPM_PACKAGE = "supercode-cli"
 
 /**
  * Valid semver pattern: MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
@@ -94,7 +94,7 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 | null {
  * Returns null on failure or if the response is malformed.
  */
 export async function fetchLatestVersion(
-  packageName: string = NPM_PACKAGE_NAME,
+  packageName: string = NPM_PACKAGE,
 ): Promise<string | null> {
   try {
     const res = await fetch(`${NPM_REGISTRY}/${packageName}/latest`, {

--- a/apps/supercode-cli/server/src/cli/utils/version.ts
+++ b/apps/supercode-cli/server/src/cli/utils/version.ts
@@ -52,12 +52,12 @@ function comparePrerelease(a: string | null, b: string | null): number {
     if (ap === undefined) return -1
     if (bp === undefined) return 1
 
-    const aNum = parseInt(ap, 10)
-    const bNum = parseInt(bp, 10)
-    const aIsNum = !isNaN(aNum)
-    const bIsNum = !isNaN(bNum)
+    const aIsNum = /^\d+$/.test(ap)
+    const bIsNum = /^\d+$/.test(bp)
 
     if (aIsNum && bIsNum) {
+      const aNum = parseInt(ap, 10)
+      const bNum = parseInt(bp, 10)
       if (aNum !== bNum) return aNum < bNum ? -1 : 1
     } else if (aIsNum) {
       return -1 // numeric < string

--- a/apps/supercode-cli/server/src/lib/cli-config.ts
+++ b/apps/supercode-cli/server/src/lib/cli-config.ts
@@ -13,6 +13,7 @@ export interface CliConfig {
   model: string
   mode: "chat" | "agent"
   apiKeys?: Partial<Record<ModelProvider, string>>
+  checkForUpdates?: boolean
   mcpServers?: Record<string, McpServerConfig>
   mcpCredentials?: Record<string, McpCredentials>
   composioApiKey?: string

--- a/apps/supercode-cli/server/src/lib/cli-config.ts
+++ b/apps/supercode-cli/server/src/lib/cli-config.ts
@@ -140,6 +140,21 @@ export async function getCliConfig(): Promise<CliConfig | null> {
   }
 }
 
+/**
+ * Read the checkForUpdates setting independently of config version guard.
+ * A preference like this should survive version bumps — it's not tied to
+ * provider/model defaults that may change between versions.
+ */
+export async function getCheckForUpdatesSetting(): Promise<boolean> {
+  try {
+    const data = await fs.readFile(CONFIG_FILE, "utf-8")
+    const config = JSON.parse(data) as CliConfig
+    return config.checkForUpdates === true
+  } catch {
+    return false
+  }
+}
+
 export async function saveCliConfig(updates: Partial<CliConfig>): Promise<CliConfig> {
   try {
     await fs.mkdir(CONFIG_DIR, { recursive: true })


### PR DESCRIPTION
Implements #91 — `supercode upgrade` self-update command.

## Changes
- New `upgrade` command with `--yes` flag to skip confirmation
- Version-comparison utility with semver comparison + npm registry fetch
- Config-gated startup version-check notification (`checkForUpdates`, default off)
- 6 tests for version comparison logic

## Files touched
- `apps/supercode-cli/server/src/cli/commands/upgrade.ts` — upgrade command
- `apps/supercode-cli/server/src/cli/utils/version.ts` — semver comparison + registry fetch
- `apps/supercode-cli/server/src/cli/utils/version.test.ts` — tests
- `apps/supercode-cli/server/src/cli/main.ts` — registered upgrade command + startup check
- `apps/supercode-cli/server/src/lib/cli-config.ts` — added `checkForUpdates` field

## Validation
- 6/6 version comparison tests pass
- Follows existing command registration pattern (commander)
- Uses `bun install -g` instead of `npm install -g`
- Startup check only fires when no subcommand is given (inside `program.action`)

Closes #91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `supercode upgrade` command that checks npm for the latest CLI version and upgrades globally after confirmation (or with `--yes`).
  * Added opt-in update notifications (`checkForUpdates`) that run after the welcome screen.
* **Bug Fixes**
  * Strengthened semantic version parsing/comparison (including prereleases/build metadata) and hardened npm “latest” lookups with clearer failure handling.
* **Tests**
  * Expanded Bun test coverage for version comparison and registry fetch outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->