### PR TITLE
feat: bump supercode-cli version to 0.1.91 and add new cloud models:

### DIFF
--- a/apps/supercode-cli/server/package.json
+++ b/apps/supercode-cli/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercode-cli",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "description": "AI-powered coding agent CLI",
   "main": "dist/main.js",
   "bin": {

--- a/apps/supercode-cli/server/src/cli/commands/slashCommands/model.ts
+++ b/apps/supercode-cli/server/src/cli/commands/slashCommands/model.ts
@@ -22,6 +22,7 @@ const SECTION_MINIMAX = "__section_minimax__"
 const SECTION_NVIDIA = "__section_nvidia__"
 const SECTION_OPENROUTER = "__section_openrouter__"
 const SECTION_ORCAROUTER = "__section_orcarouter__"
+const SECTION_CLOUD_PREMIUM = "__section_cloud_premium__"
 
 export const ALL_SECTIONS = new Set([
   SECTION_CLOUD, SECTION_BYOK,
@@ -29,6 +30,7 @@ export const ALL_SECTIONS = new Set([
   SECTION_GOOGLE, SECTION_MINIMAX,
   SECTION_NVIDIA, SECTION_OPENROUTER,
   SECTION_ORCAROUTER,
+  SECTION_CLOUD_PREMIUM,
 ])
 
 const SECTION_LABELS: Record<string, string> = {
@@ -41,18 +43,21 @@ const SECTION_LABELS: Record<string, string> = {
   [SECTION_NVIDIA]: "NVIDIA NIM",
   [SECTION_OPENROUTER]: "OpenRouter",
   [SECTION_ORCAROUTER]: "OrcaRouter",
+  [SECTION_CLOUD_PREMIUM]: "Supercode Cloud Premium",
 }
 
-const isMainSection = (v: string) => v === SECTION_CLOUD || v === SECTION_BYOK
+const isMainSection = (v: string) => v === SECTION_CLOUD || v === SECTION_BYOK || v === SECTION_CLOUD_PREMIUM
 
 // Models available through the Supercode cloud proxy (no API key needed)
 export const CLOUD_MODELS: ModelEntry[] = [
   { value: "deepseek-v4-flash", label: "DeepSeek V4 Flash", provider: "supercode", cost: "free", desc: "Fast & capable" },
-  { value: "glm-5.2", label: "GLM 5.2", provider: "supercode", cost: "free", desc: "Latest GLM" },
-  { value: "glm-5.1", label: "GLM 5.1", provider: "supercode", cost: "free", desc: "Stable & reliable" },
-  { value: "kimi-k2-6", label: "Kimi K2.6", provider: "supercode", cost: "free", desc: "Long context" },
-  { value: "minimax-m3", label: "MiniMax M3", provider: "supercode", cost: "free", desc: "Fast & smart" },
+  // { value: "glm-5.2", label: "GLM 5.2", provider: "supercode", cost: "free", desc: "Latest GLM" },
+  // { value: "glm-5.1", label: "GLM 5.1", provider: "supercode", cost: "free", desc: "Stable & reliable" },
+  // { value: "kimi-k2-6", label: "Kimi K2.6", provider: "supercode", cost: "free", desc: "Long context" },
+  // { value: "minimax-m3", label: "MiniMax M3", provider: "supercode", cost: "free", desc: "Fast & smart" },
   { value: "hy3", label: "Hunyuan Hy3", provider: "supercode", cost: "free", desc: "Tencent flagship" },
+  { value: "mimo-v2.5", label: "Mimo v2.5", provider: "supercode", cost: "free", desc: "Novita" },
+  // { value: "fireworks/nemotron-3-ultra-nvfp4", label: "Nemotron 3 Ultra NVFP4", provider: "supercode", cost: "free", desc: "Fireworks" },
 ]
 
 // Models available when you bring your own API key (BYOK)
@@ -199,9 +204,22 @@ export const BYOK_MODELS: ModelEntry[] = [
   { value: "orcarouter/auto", label: "OrcaRouter Auto", provider: "orcarouter", cost: "0x", desc: "Auto-pick cheapest" },
 ]
 
+// Set of premium cloud models that require Supercode Cloud Premium
+export const PREMIUM_CLOUD_MODELS = new Set([
+  "glm-5.2",
+  "kimi-k2-7-code",
+  "kimi-k3",
+  "minimax-m3",
+])
+
 export const MODELS: ModelEntry[] = [
   { value: SECTION_CLOUD, label: "Supercode Cloud", provider: "supercode", cost: "", desc: "" },
   ...CLOUD_MODELS,
+  { value: SECTION_CLOUD_PREMIUM, label: "Supercode Cloud Premium", provider: "supercode", cost: "", desc: "" },
+  { value: "glm-5.2", label: "GLM 5.2", provider: "supercode", cost: "", desc: "Latest GLM" },
+  { value: "kimi-k2-7-code", label: "Kimi K2.7 Code", provider: "supercode", cost: "", desc: "Code specialist" },
+  { value: "kimi-k3", label: "Kimi K3", provider: "supercode", cost: "", desc: "Moonshot latest" },
+  { value: "minimax-m3", label: "MiniMax M3", provider: "supercode", cost: "", desc: "Fast & smart" },
   { value: SECTION_BYOK, label: "Bring Your Own Key", provider: "supercode", cost: "", desc: "" },
   ...BYOK_MODELS,
 ]
@@ -366,16 +384,21 @@ export class ModelPicker {
       const marker = isCurrent
         ? ` ${chalk.bgHex(theme.amber).hex(theme.black).bold(" current ")}`
         : ""
+      const isPremium = PREMIUM_CLOUD_MODELS.has(m.value)
       const cloudTag =
-        m.provider === "supercode" && !isCurrent
+        m.provider === "supercode" && !isCurrent && !isPremium
           ? ` ${chalk.bgHex(theme.green).hex(theme.black).bold(" CLOUD ")}`
+          : ""
+      const premiumTag =
+        isPremium && !isCurrent
+          ? ` ${chalk.bgHex(theme.amber).hex(theme.black).bold(" PREMIUM ")}`
           : ""
       const freeTag =
         !isCurrent && m.cost === "free" && m.provider !== "supercode"
           ? ` ${chalk.bgHex(theme.green).hex(theme.black).bold(" FREE ")}`
           : ""
 
-      const label = `${prefix} ${name} ${cost}${desc}${marker}${cloudTag}${freeTag}`
+      const label = `${prefix} ${name} ${cost}${desc}${marker}${cloudTag}${premiumTag}${freeTag}`
 
       if (isSelected) {
         const bg = chalk.bgHex(theme.greenDeep)
@@ -583,6 +606,21 @@ export async function pickModel(
       `  ${chalk.hex(theme.green)("✓")} model set to ${chalk.hex(theme.greenGlow)(trimmed)}\n\n`,
     )
     return { provider: selected.provider, model: trimmed }
+  }
+
+  // Premium cloud models require Supercode Cloud Premium
+  if (PREMIUM_CLOUD_MODELS.has(selected.value)) {
+    process.stdout.write("\n")
+    process.stdout.write(
+      ` ${chalk.hex(theme.amber)("◆")}  ${chalk.hex(theme.green).bold("Supercode Cloud Premium")}
+
+   ${chalk.hex(theme.muted)("This model is available on Supercode Cloud Premium.")}
+   ${chalk.hex(theme.muted)("Upgrade your plan to access premium models.")}
+   ${chalk.hex(theme.muted)("→ https://supercode.ai/pricing")}
+
+`
+    )
+    return { provider: currentProvider as ModelProvider, model: currentModel }
   }
 
   // For BYOK providers, check if an API key is configured

--- a/apps/supercode-cli/server/src/index.ts
+++ b/apps/supercode-cli/server/src/index.ts
@@ -66,6 +66,10 @@ const CLOUD_ALLOWED_MODELS = new Set([
   "kimi-k2-6",
   "minimax-m3",
   "hy3",
+  "mimo-v2.5",
+  "fireworks/nemotron-3-ultra-nvfp4",
+  "kimi-k2-7-code",
+  "kimi-k3",
 ])
 const JSON_BODY_LIMIT = process.env.SUPERCODE_JSON_BODY_LIMIT || "10mb"
 const app = express()

--- a/apps/supercode-cli/server/src/lib/pricing.ts
+++ b/apps/supercode-cli/server/src/lib/pricing.ts
@@ -36,6 +36,10 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   "deepseek/deepseek-reasoner": { inputPrice: 0.50, outputPrice: 2.00,  cachedPrice: 0 },
   "grok/grok-4-fast-reasoning": { inputPrice: 1.00, outputPrice: 5.00,  cachedPrice: 0 },
   "orcarouter/auto":         { inputPrice: 0,      outputPrice: 0,      cachedPrice: 0 },
+  "mimo-v2.5":              { inputPrice: 0.15,   outputPrice: 0.60,   cachedPrice: 0 },
+  "fireworks/nemotron-3-ultra-nvfp4": { inputPrice: 0.60, outputPrice: 2.40, cachedPrice: 0.12 },
+  "kimi-k2-7-code":         { inputPrice: 0.25,   outputPrice: 1.00,   cachedPrice: 0 },
+  "kimi-k3":                { inputPrice: 0.50,   outputPrice: 2.00,   cachedPrice: 0 },
 }
 
 export function computeCost(model: string, inputTokens: number, outputTokens: number, cachedInputTokens: number): number {


### PR DESCRIPTION


## Description

- Updated version in package.json to 0.1.91.
- Added new cloud models: "mimo-v2.5", "fireworks/nemotron-3-ultra-nvfp4", "kimi-k2-7-code", and "kimi-k3".
- Introduced a new premium section for cloud models requiring Supercode Cloud Premium.
- Enhanced model selection logic to include premium tags for better user experience.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (if applicable)

## Checklist:

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Supercode Cloud Premium section to model selection.
  * Premium models now display a clear “PREMIUM” label.
  * Added support for additional cloud models, including Mimo, Kimi, Nemotron, and other premium options.
  * Added pricing information for newly supported models.

* **Bug Fixes**
  * Premium model selections now provide an upgrade notice and preserve the current model when access is unavailable.

* **Chores**
  * Updated the CLI release version to 0.1.91.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->