### PR TITLE
feat: enhance AI review process with Linear integration:

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -76,3 +76,7 @@ COMPOSIO_API_KEY=
 # auth config for the toolkit, then uses connectedAccounts.link with our callback URL.
 # COMPOSIO_SLACK_AUTH_CONFIG_ID=
 # COMPOSIO_LINEAR_AUTH_CONFIG_ID=
+# Toolkit version required by tools.execute (defaults to "latest" if unset).
+# COMPOSIO_TOOLKIT_VERSION=latest
+# COMPOSIO_TOOLKIT_VERSION_LINEAR=latest
+# COMPOSIO_TOOLKIT_VERSION_SLACK=latest

--- a/apps/web/inngest/functions/ai-review.ts
+++ b/apps/web/inngest/functions/ai-review.ts
@@ -91,7 +91,7 @@ export const generateReview = inngest.createFunction(
       })
 
       console.log(
-        `[generate-review] done ${owner}/${repo}#${prNumber} files=${result.files} commentPosted=${result.commentPosted}`,
+        `[generate-review] done ${owner}/${repo}#${prNumber} files=${result.files} commentPosted=${result.commentPosted} linearNotified=${Boolean(result.linearNotified)} linearIssue=${result.linearIssueId ?? result.linearSkippedReason ?? "-"}`,
       )
 
       return {
@@ -101,6 +101,9 @@ export const generateReview = inngest.createFunction(
         prNumber: result.prNumber,
         files: result.files,
         commentPosted: result.commentPosted,
+        linearNotified: result.linearNotified ?? false,
+        linearIssueId: result.linearIssueId ?? null,
+        linearSkippedReason: result.linearSkippedReason ?? null,
       }
     })
   },

--- a/apps/web/modules/ai/lib/generate-pr-review.ts
+++ b/apps/web/modules/ai/lib/generate-pr-review.ts
@@ -138,6 +138,9 @@ export type GeneratePrReviewResult = {
   files: number
   commentPosted: boolean
   review: string
+  linearNotified?: boolean
+  linearIssueId?: string | null
+  linearSkippedReason?: string | null
 }
 
 function isRealUserId(userId: string | undefined | null): userId is string {
@@ -366,12 +369,14 @@ export async function runGeneratePrReview(
   }
 
   const review = text
+  const prUrl = `https://github.com/${owner}/${repo}/pull/${prNumber}`
 
   const repository = await findRepository(owner, repo, userId)
+  let reviewId: string | null = null
   if (!repository) {
     console.warn(`[generate-pr-review] repository ${repoId} missing when saving`)
   } else {
-    await prisma.review.upsert({
+    const saved = await prisma.review.upsert({
       where: {
         repositoryId_prNumber: {
           repositoryId: repository.id,
@@ -380,7 +385,7 @@ export async function runGeneratePrReview(
       },
       update: {
         prTitle: prData.title,
-        prUrl: `https://github.com/${owner}/${repo}/pull/${prNumber}`,
+        prUrl,
         review,
         status: "completed",
       },
@@ -388,11 +393,13 @@ export async function runGeneratePrReview(
         repositoryId: repository.id,
         prNumber,
         prTitle: prData.title,
-        prUrl: `https://github.com/${owner}/${repo}/pull/${prNumber}`,
+        prUrl,
         review,
         status: "completed",
       },
+      select: { id: true },
     })
+    reviewId = saved.id
   }
 
   // Persist completed review first so the dashboard is correct even if GitHub
@@ -416,6 +423,45 @@ export async function runGeneratePrReview(
     )
   }
 
+  // Push review into connected Linear workspace (Supercode AI project).
+  // Best-effort — never fail the review job if Linear/Composio is down.
+  let linearNotified = false
+  let linearIssueId: string | null = null
+  let linearSkippedReason: string | null = null
+  try {
+    const { notifyLinearOfCompletedReview } = await import(
+      "@/modules/integrations/lib/linear"
+    )
+    const linearResult = await notifyLinearOfCompletedReview({
+      userId,
+      owner,
+      repo,
+      prNumber,
+      prTitle: prData.title,
+      prUrl,
+      prDescription: prData.description || "",
+      reviewMarkdown: review,
+      reviewId,
+    })
+    if (linearResult.skipped) {
+      linearSkippedReason = linearResult.reason ?? "skipped"
+      console.log(
+        `[generate-pr-review] linear notify skipped for ${repoId}#${prNumber}: ${linearSkippedReason}`,
+      )
+    } else {
+      linearNotified = true
+      linearIssueId = linearResult.issueId ?? null
+      console.log(
+        `[generate-pr-review] linear notify ok for ${repoId}#${prNumber} issue=${linearIssueId ?? "?"} updated=${Boolean(linearResult.updated)} project=${linearResult.projectId ?? "?"}`,
+      )
+    }
+  } catch (error) {
+    console.error(
+      `[generate-pr-review] linear notify failed for ${repoId}#${prNumber} (review still saved):`,
+      error,
+    )
+  }
+
   return {
     success: true,
     owner,
@@ -424,5 +470,8 @@ export async function runGeneratePrReview(
     files: prData.changedFiles.length,
     commentPosted,
     review,
+    linearNotified,
+    linearIssueId,
+    linearSkippedReason,
   }
 }

--- a/apps/web/modules/integrations/actions/index.ts
+++ b/apps/web/modules/integrations/actions/index.ts
@@ -13,8 +13,12 @@ import {
   deleteComposioConnectedAccount,
   isComposioConfigured,
 } from "../lib/composio"
+import { getLinearTeamsForConnectedAccount } from "../lib/linear"
 import type { IntegrationProvider, IntegrationStatus } from "./schema"
-import { integrationProviderSchema } from "./schema"
+import {
+  integrationProviderSchema,
+  updateLinearConfigSchema,
+} from "./schema"
 
 async function requireSessionUserId(): Promise<string> {
   const session = await auth.api.getSession({
@@ -264,5 +268,142 @@ export async function updateSlackChannel(channelId: string | null) {
   } catch (error) {
     console.error("updateSlackChannel failed:", error)
     return { success: false as const, error: "Failed to update Slack channel" }
+  }
+}
+
+export type LinearTeamOption = {
+  id: string
+  name: string | null
+}
+
+/**
+ * List Linear teams (workspaces) for the connected org account.
+ * Used after first connect so the user can choose where supercodeAI lives.
+ */
+export async function listLinearTeams(): Promise<{
+  success: true
+  teams: LinearTeamOption[]
+  selectedTeamId: string | null
+} | {
+  success: false
+  error: string
+}> {
+  try {
+    const userId = await requireSessionUserId()
+    const organizationId = await getOrganizationIdForUser(userId)
+    if (!organizationId) {
+      return { success: false, error: "No organization found" }
+    }
+    if (!isComposioConfigured()) {
+      return { success: false, error: "COMPOSIO_API_KEY is not configured" }
+    }
+
+    const existing = await prisma.integration.findUnique({
+      where: {
+        organizationId_provider: {
+          organizationId,
+          provider: "linear",
+        },
+      },
+    })
+
+    if (!existing?.isActive || !existing.composioConnectedAccountId) {
+      return { success: false, error: "Linear is not connected" }
+    }
+
+    const entityId =
+      existing.composioEntityId || composioEntityIdForOrg(organizationId)
+    const teams = await getLinearTeamsForConnectedAccount({
+      entityId,
+      connectedAccountId: existing.composioConnectedAccountId,
+    })
+
+    return {
+      success: true,
+      teams,
+      selectedTeamId: existing.linearTeamId ?? null,
+    }
+  } catch (error) {
+    console.error("listLinearTeams failed:", error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to list Linear teams",
+    }
+  }
+}
+
+export async function updateLinearTeam(
+  teamId: string | null,
+  teamName?: string | null,
+) {
+  try {
+    const parsed = updateLinearConfigSchema.safeParse({
+      teamId,
+      teamName: teamName ?? null,
+    })
+    if (!parsed.success) {
+      return { success: false as const, error: "Invalid team selection" }
+    }
+
+    const userId = await requireSessionUserId()
+    const organizationId = await getOrganizationIdForUser(userId)
+    if (!organizationId) {
+      return { success: false as const, error: "No organization found" }
+    }
+
+    const existing = await prisma.integration.findUnique({
+      where: {
+        organizationId_provider: {
+          organizationId,
+          provider: "linear",
+        },
+      },
+    })
+
+    if (!existing?.isActive || !existing.composioConnectedAccountId) {
+      return { success: false as const, error: "Linear is not connected" }
+    }
+
+    const nextTeamId = parsed.data.teamId ?? null
+    const nextTeamName = parsed.data.teamName ?? null
+
+// Keep supercodeAiProjectId only if team unchanged; otherwise clear so
+    // notify recreates/finds project under the newly selected team.
+    const prevConfig =
+      existing.config &&
+      typeof existing.config === "object" &&
+      !Array.isArray(existing.config)
+        ? { ...(existing.config as Record<string, unknown>) }
+        : ({} as Record<string, unknown>)
+    const teamChanged =
+      Boolean(nextTeamId) && nextTeamId !== existing.linearTeamId
+    const nextConfig: Record<string, unknown> = { ...prevConfig }
+
+    if (nextTeamId) {
+      nextConfig.supercodeAiTeamId = nextTeamId
+    }
+    if (teamChanged) {
+      delete nextConfig.supercodeAiProjectId
+    }
+
+await prisma.integration.update({
+      where: { id: existing.id },
+      data: {
+        linearTeamId: nextTeamId,
+        linearTeamName: nextTeamName,
+        // Prisma Json input rejects plain Record<string, unknown>
+        config: nextConfig as object,
+      },
+    })
+
+    revalidatePath("/dashboard/integrations", "page")
+    revalidatePath("/dashboard/settings", "page")
+    return { success: true as const }
+  } catch (error) {
+    console.error("updateLinearTeam failed:", error)
+    return { success: false as const, error: "Failed to update Linear team" }
   }
 }

--- a/apps/web/modules/integrations/components/integrations-page.tsx
+++ b/apps/web/modules/integrations/components/integrations-page.tsx
@@ -8,7 +8,10 @@ import { toast } from "sonner"
 import {
   disconnectIntegration,
   getIntegrationStatuses,
+  listLinearTeams,
+  updateLinearTeam,
   updateSlackChannel,
+  type LinearTeamOption,
 } from "@/modules/integrations/actions"
 import type {
   IntegrationProvider,
@@ -137,6 +140,13 @@ export function IntegrationsPage() {
   const [searchQuery, setSearchQuery] = useState("")
   const [channelDialogOpen, setChannelDialogOpen] = useState(false)
   const [channelDraft, setChannelDraft] = useState("")
+  const [linearDialogOpen, setLinearDialogOpen] = useState(false)
+  const [linearTeams, setLinearTeams] = useState<LinearTeamOption[]>([])
+  const [linearTeamDraft, setLinearTeamDraft] = useState("")
+  const [linearTeamsLoading, setLinearTeamsLoading] = useState(false)
+  const [linearTeamsError, setLinearTeamsError] = useState<string | null>(null)
+  const [promptLinearTeamAfterConnect, setPromptLinearTeamAfterConnect] =
+    useState(false)
 
   const { data, isLoading, isFetching, refetch } = useQuery({
     queryKey: ["integration-statuses"],
@@ -145,6 +155,32 @@ export function IntegrationsPage() {
     refetchOnWindowFocus: false,
   })
 
+  const openLinearTeamDialog = async (opts?: { preferredTeamId?: string | null }) => {
+    setLinearDialogOpen(true)
+    setLinearTeamsLoading(true)
+    setLinearTeamsError(null)
+    try {
+      const result = await listLinearTeams()
+      if (!result.success) {
+        setLinearTeams([])
+        setLinearTeamsError(result.error || "Failed to load Linear teams")
+        return
+      }
+      setLinearTeams(result.teams)
+      const preferred =
+        opts?.preferredTeamId ||
+        result.selectedTeamId ||
+        result.teams[0]?.id ||
+        ""
+      setLinearTeamDraft(preferred)
+    } catch {
+      setLinearTeams([])
+      setLinearTeamsError("Failed to load Linear teams")
+    } finally {
+      setLinearTeamsLoading(false)
+    }
+  }
+
   useEffect(() => {
     const connected = searchParams.get("connected")
     const error = searchParams.get("integration_error")
@@ -152,9 +188,12 @@ export function IntegrationsPage() {
       toast.success(
         connected === "slack"
           ? "Slack connected via Composio"
-          : "Linear connected via Composio",
+          : "Linear connected via Composio — choose a workspace",
       )
       queryClient.invalidateQueries({ queryKey: ["integration-statuses"] })
+      if (connected === "linear") {
+        setPromptLinearTeamAfterConnect(true)
+      }
       const url = new URL(window.location.href)
       url.searchParams.delete("connected")
       url.searchParams.delete("integration_error")
@@ -167,6 +206,15 @@ export function IntegrationsPage() {
       window.history.replaceState({}, "", url.pathname + url.search)
     }
   }, [searchParams, queryClient])
+
+  // After Linear OAuth, open workspace picker once statuses are fresh.
+  useEffect(() => {
+    if (!promptLinearTeamAfterConnect || isLoading || !data?.linear?.connected) {
+      return
+    }
+    setPromptLinearTeamAfterConnect(false)
+    void openLinearTeamDialog({ preferredTeamId: data.linear.teamId })
+  }, [promptLinearTeamAfterConnect, isLoading, data])
 
   const disconnectMutation = useMutation({
     mutationFn: async (provider: IntegrationProvider) =>
@@ -196,6 +244,21 @@ export function IntegrationsPage() {
       }
     },
     onError: () => toast.error("Failed to update channel"),
+  })
+
+  const linearTeamMutation = useMutation({
+    mutationFn: async (payload: { teamId: string; teamName: string | null }) =>
+      updateLinearTeam(payload.teamId, payload.teamName),
+    onSuccess: (result) => {
+      if (result?.success) {
+        queryClient.invalidateQueries({ queryKey: ["integration-statuses"] })
+        toast.success("Linear workspace saved — reviews will use supercodeAI here")
+        setLinearDialogOpen(false)
+      } else {
+        toast.error(result?.error || "Failed to save Linear workspace")
+      }
+    },
+    onError: () => toast.error("Failed to save Linear workspace"),
   })
 
   const composioConfigured = data?.composioConfigured ?? false
@@ -403,12 +466,18 @@ export function IntegrationsPage() {
                     </div>
                   </div>
 
-                  {connected ? (
+{connected ? (
                     <div className="mt-4 rounded-lg border border-border bg-muted/10 px-3 py-2 text-xs text-muted-foreground">
                       {status?.teamName ? (
                         <p>
                           Workspace:{" "}
                           <span className="text-foreground">{status.teamName}</span>
+                        </p>
+                      ) : app.id === "linear" ? (
+                        <p className="text-amber-700 dark:text-amber-300">
+                          Connected — choose a Linear workspace so reviews create
+                          the shared <span className="font-medium">supercodeAI</span>{" "}
+                          project.
                         </p>
                       ) : (
                         <p>Connected account active via Composio</p>
@@ -442,7 +511,7 @@ export function IntegrationsPage() {
                   </ul>
 
                   <div className="mt-5 flex flex-wrap items-center gap-2 border-t border-border pt-4">
-                    {connected ? (
+{connected ? (
                       <>
                         {app.id === "slack" ? (
                           <Button
@@ -455,6 +524,20 @@ export function IntegrationsPage() {
                             }}
                           >
                             Configure channel
+                          </Button>
+                        ) : null}
+                        {app.id === "linear" ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-8 rounded-lg text-xs"
+                            onClick={() =>
+                              void openLinearTeamDialog({
+                                preferredTeamId: status?.teamId,
+                              })
+                            }
+                          >
+                            {status?.teamId ? "Change workspace" : "Choose workspace"}
                           </Button>
                         ) : null}
                         <Button
@@ -523,7 +606,7 @@ export function IntegrationsPage() {
         ) : null}
       </motion.div>
 
-      <Dialog open={channelDialogOpen} onOpenChange={setChannelDialogOpen}>
+<Dialog open={channelDialogOpen} onOpenChange={setChannelDialogOpen}>
         <DialogContent className="sm:max-w-[425px] rounded-xl">
           <DialogHeader>
             <DialogTitle>Slack notification channel</DialogTitle>
@@ -558,6 +641,78 @@ export function IntegrationsPage() {
               }
             >
               {channelMutation.isPending ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={linearDialogOpen} onOpenChange={setLinearDialogOpen}>
+        <DialogContent className="sm:max-w-[425px] rounded-xl">
+          <DialogHeader>
+            <DialogTitle>Linear workspace</DialogTitle>
+            <DialogDescription>
+              Choose the Linear team where Supercode creates the shared{" "}
+              <span className="font-medium text-foreground">supercodeAI</span>{" "}
+              project and posts PR review issues.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-2 py-2">
+            <Label htmlFor="linear-team">Team / workspace</Label>
+            {linearTeamsLoading ? (
+              <div className="flex h-10 items-center gap-2 rounded-lg border border-border bg-muted/20 px-3 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Loading teams…
+              </div>
+            ) : linearTeamsError ? (
+              <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                {linearTeamsError}
+              </div>
+            ) : linearTeams.length === 0 ? (
+              <div className="rounded-lg border border-border bg-muted/10 px-3 py-2 text-xs text-muted-foreground">
+                No Linear teams found for this account.
+              </div>
+            ) : (
+              <select
+                id="linear-team"
+                value={linearTeamDraft}
+                onChange={(e) => setLinearTeamDraft(e.target.value)}
+                className="h-10 w-full rounded-lg border border-border bg-background px-3 text-sm text-foreground focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/20"
+              >
+                {linearTeams.map((team) => (
+                  <option key={team.id} value={team.id}>
+                    {team.name || team.id}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              className="rounded-lg"
+              onClick={() => setLinearDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              className="rounded-lg"
+              disabled={
+                linearTeamMutation.isPending ||
+                linearTeamsLoading ||
+                !linearTeamDraft.trim() ||
+                Boolean(linearTeamsError)
+              }
+              onClick={() => {
+                const team =
+                  linearTeams.find((t) => t.id === linearTeamDraft) || null
+                if (!team) return
+                linearTeamMutation.mutate({
+                  teamId: team.id,
+                  teamName: team.name,
+                })
+              }}
+            >
+              {linearTeamMutation.isPending ? "Saving..." : "Save workspace"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/modules/integrations/lib/composio.ts
+++ b/apps/web/modules/integrations/lib/composio.ts
@@ -7,6 +7,37 @@ export const COMPOSIO_TOOLKIT: Record<IntegrationProvider, string> = {
   linear: "linear",
 }
 
+/**
+ * Composio requires an explicit toolkit version on tools.execute (TS-SDK::TOOL_VERSION_REQUIRED).
+ * Prefer COMPOSIO_TOOLKIT_VERSION_<SLUG>, then COMPOSIO_TOOLKIT_VERSION, then "latest".
+ */
+export function resolveComposioToolkitVersion(toolkitSlug: string): string {
+  const slug = toolkitSlug.trim().toLowerCase()
+  const envKey = `COMPOSIO_TOOLKIT_VERSION_${slug.replace(/[^a-z0-9]+/g, "_").toUpperCase()}`
+  return (
+    process.env[envKey]?.trim() ||
+    process.env.COMPOSIO_TOOLKIT_VERSION?.trim() ||
+    "latest"
+  )
+}
+
+function toolkitVersionsFromEnv(): Record<string, string> {
+  const versions: Record<string, string> = {}
+  for (const slug of Object.values(COMPOSIO_TOOLKIT)) {
+    versions[slug] = resolveComposioToolkitVersion(slug)
+  }
+  return versions
+}
+
+function toolkitSlugFromToolSlug(toolSlug: string): string | null {
+  const upper = toolSlug.trim().toUpperCase()
+  for (const slug of Object.values(COMPOSIO_TOOLKIT)) {
+    if (upper.startsWith(`${slug.toUpperCase()}_`)) return slug
+  }
+  const head = toolSlug.split("_")[0]?.toLowerCase()
+  return head || null
+}
+
 let composioSingleton: Composio | null = null
 
 export function isComposioConfigured(): boolean {
@@ -19,7 +50,11 @@ export function getComposio(): Composio {
     throw new Error("COMPOSIO_API_KEY is not configured")
   }
   if (!composioSingleton) {
-    composioSingleton = new Composio({ apiKey })
+    composioSingleton = new Composio({
+      apiKey,
+      // SDK-level defaults; execute still passes version explicitly for safety.
+      toolkitVersions: toolkitVersionsFromEnv(),
+    })
   }
   return composioSingleton
 }
@@ -414,17 +449,28 @@ export async function deleteComposioConnectedAccount(
 
 /**
  * Execute a Composio tool for a connected account (Phase 2+ notifications).
+ * Always passes toolkit `version` to satisfy TS-SDK::TOOL_VERSION_REQUIRED.
  */
 export async function executeComposioTool(params: {
   toolSlug: string
   userId: string // composio entity id
   arguments: Record<string, unknown>
   connectedAccountId?: string
+  /** Override toolkit version; defaults from env / "latest". */
+  version?: string
 }) {
   const composio = getComposio()
+  const toolkitSlug = toolkitSlugFromToolSlug(params.toolSlug)
+  const version =
+    params.version?.trim() ||
+    (toolkitSlug
+      ? resolveComposioToolkitVersion(toolkitSlug)
+      : process.env.COMPOSIO_TOOLKIT_VERSION?.trim() || "latest")
+
   return composio.tools.execute(params.toolSlug, {
     userId: params.userId,
     arguments: params.arguments,
+    version,
     ...(params.connectedAccountId
       ? { connectedAccountId: params.connectedAccountId }
       : {}),

--- a/apps/web/modules/integrations/lib/linear.ts
+++ b/apps/web/modules/integrations/lib/linear.ts
@@ -1,4 +1,185 @@
-import { executeComposioTool } from "./composio"
+import prisma from "@super/db"
+import {
+  composioEntityIdForOrg,
+  executeComposioTool,
+  isComposioConfigured,
+} from "./composio"
+import { getOrganizationIdForUser } from "./org"
+
+/** Canonical Linear project for all Supercode Review issues (create once, reuse forever). */
+export const SUPERCODE_AI_PROJECT_NAME = "supercodeAI"
+
+const MAX_LINEAR_DESCRIPTION_CHARS = 60_000
+
+function normalizeProjectName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "")
+}
+
+/** Match supercodeAI / Supercode AI / supercode-ai / etc. */
+function isSupercodeAiProjectName(name: string | null | undefined): boolean {
+  if (!name) return false
+  return normalizeProjectName(name) === normalizeProjectName(SUPERCODE_AI_PROJECT_NAME)
+}
+
+type LinearConfig = {
+  supercodeAiProjectId?: string
+  supercodeAiTeamId?: string
+}
+
+type ToolResult = {
+  successful?: boolean
+  data?: unknown
+  error?: unknown
+  [key: string]: unknown
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function unwrapData(result: unknown): unknown {
+  const root = asRecord(result)
+  if (!root) return result
+  if ("data" in root) return root.data
+  return result
+}
+
+function collectObjects(value: unknown, out: Record<string, unknown>[] = []): Record<string, unknown>[] {
+  if (Array.isArray(value)) {
+    for (const item of value) collectObjects(item, out)
+    return out
+  }
+  const obj = asRecord(value)
+  if (!obj) return out
+  out.push(obj)
+  for (const nested of Object.values(obj)) {
+    if (nested && typeof nested === "object") collectObjects(nested, out)
+  }
+  return out
+}
+
+function pickString(obj: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = obj[key]
+    if (typeof value === "string" && value.trim()) return value.trim()
+  }
+  return null
+}
+
+function extractId(result: unknown, preferKeys: string[] = ["id"]): string | null {
+  for (const obj of collectObjects(unwrapData(result))) {
+    const id = pickString(obj, preferKeys)
+    if (id) return id
+  }
+  return null
+}
+
+function extractTeams(result: unknown): Array<{ id: string; name: string | null }> {
+  const teams: Array<{ id: string; name: string | null }> = []
+  const seen = new Set<string>()
+  for (const obj of collectObjects(unwrapData(result))) {
+    const id = pickString(obj, ["id", "teamId", "team_id"])
+    if (!id || seen.has(id)) continue
+    const name = pickString(obj, ["name", "displayName", "display_name"])
+    const key = pickString(obj, ["key"])
+    if (!name && !key) continue
+    if (pickString(obj, ["identifier"]) && !key) continue
+    seen.add(id)
+    teams.push({ id, name })
+  }
+  return teams
+}
+
+function extractProjects(result: unknown): Array<{ id: string; name: string | null }> {
+  const projects: Array<{ id: string; name: string | null }> = []
+  const seen = new Set<string>()
+  for (const obj of collectObjects(unwrapData(result))) {
+    const id = pickString(obj, ["id", "projectId", "project_id"])
+    const name = pickString(obj, ["name"])
+    if (!id || !name || seen.has(id)) continue
+    if (pickString(obj, ["identifier", "number"])) continue
+    seen.add(id)
+    projects.push({ id, name })
+  }
+  return projects
+}
+
+function extractIssues(result: unknown): Array<{
+  id: string
+  title: string | null
+  identifier: string | null
+  url: string | null
+  description: string | null
+}> {
+  const issues: Array<{
+    id: string
+    title: string | null
+    identifier: string | null
+    url: string | null
+    description: string | null
+  }> = []
+  const seen = new Set<string>()
+  for (const obj of collectObjects(unwrapData(result))) {
+    const id = pickString(obj, ["id", "issueId", "issue_id"])
+    if (!id || seen.has(id)) continue
+    const title = pickString(obj, ["title"])
+    const identifier = pickString(obj, ["identifier"])
+    const url = pickString(obj, ["url", "issueUrl", "issue_url"])
+    const description = pickString(obj, ["description", "body"])
+    if (!title && !identifier) continue
+    seen.add(id)
+    issues.push({ id, title, identifier, url, description })
+  }
+  return issues
+}
+
+function assertToolOk(result: unknown, label: string) {
+  const root = asRecord(result)
+  if (root && root.successful === false) {
+    const err =
+      typeof root.error === "string"
+        ? root.error
+        : root.error
+          ? JSON.stringify(root.error)
+          : "unknown error"
+    throw new Error(`${label} failed: ${err}`)
+  }
+}
+
+function truncate(text: string, max: number) {
+  if (text.length <= max) return text
+  return `${text.slice(0, max)}\n\n…truncated (${text.length} → ${max} chars)`
+}
+
+function readLinearConfig(config: unknown): LinearConfig {
+  const obj = asRecord(config)
+  if (!obj) return {}
+  return {
+    supercodeAiProjectId:
+      typeof obj.supercodeAiProjectId === "string"
+        ? obj.supercodeAiProjectId
+        : undefined,
+    supercodeAiTeamId:
+      typeof obj.supercodeAiTeamId === "string" ? obj.supercodeAiTeamId : undefined,
+  }
+}
+
+async function runLinearTool(params: {
+  entityId: string
+  connectedAccountId: string
+  toolSlug: string
+  arguments: Record<string, unknown>
+}): Promise<ToolResult> {
+  const result = (await executeComposioTool({
+    toolSlug: params.toolSlug,
+    userId: params.entityId,
+    connectedAccountId: params.connectedAccountId,
+    arguments: params.arguments,
+  })) as ToolResult
+  assertToolOk(result, params.toolSlug)
+  return result
+}
 
 export async function createLinearCommentViaComposio(params: {
   entityId: string
@@ -6,10 +187,10 @@ export async function createLinearCommentViaComposio(params: {
   issueId: string
   body: string
 }) {
-  return executeComposioTool({
-    toolSlug: "LINEAR_CREATE_LINEAR_COMMENT",
-    userId: params.entityId,
+  return runLinearTool({
+    entityId: params.entityId,
     connectedAccountId: params.connectedAccountId,
+    toolSlug: "LINEAR_CREATE_LINEAR_COMMENT",
     arguments: {
       issueId: params.issueId,
       body: params.body,
@@ -23,15 +204,568 @@ export async function createLinearIssueViaComposio(params: {
   title: string
   description?: string
   teamId: string
+  projectId?: string
 }) {
-  return executeComposioTool({
-    toolSlug: "LINEAR_CREATE_LINEAR_ISSUE",
-    userId: params.entityId,
+  return runLinearTool({
+    entityId: params.entityId,
     connectedAccountId: params.connectedAccountId,
+    toolSlug: "LINEAR_CREATE_LINEAR_ISSUE",
     arguments: {
       title: params.title,
-      description: params.description,
-      teamId: params.teamId,
+      team_id: params.teamId,
+      ...(params.description ? { description: params.description } : {}),
+      ...(params.projectId ? { project_id: params.projectId } : {}),
     },
   })
+}
+
+export async function listLinearTeamsViaComposio(params: {
+  entityId: string
+  connectedAccountId: string
+}) {
+  return runLinearTool({
+    entityId: params.entityId,
+    connectedAccountId: params.connectedAccountId,
+    toolSlug: "LINEAR_GET_ALL_LINEAR_TEAMS",
+    arguments: {},
+  })
+}
+
+export async function listLinearProjectsViaComposio(params: {
+  entityId: string
+  connectedAccountId: string
+}) {
+  return runLinearTool({
+    entityId: params.entityId,
+    connectedAccountId: params.connectedAccountId,
+    toolSlug: "LINEAR_LIST_LINEAR_PROJECTS",
+    arguments: {},
+  })
+}
+
+export async function createLinearProjectViaComposio(params: {
+  entityId: string
+  connectedAccountId: string
+  name: string
+  teamIds: string[]
+  description?: string
+}) {
+  return runLinearTool({
+    entityId: params.entityId,
+    connectedAccountId: params.connectedAccountId,
+    toolSlug: "LINEAR_CREATE_LINEAR_PROJECT",
+    arguments: {
+      name: params.name,
+      team_ids: params.teamIds,
+      ...(params.description ? { description: params.description } : {}),
+    },
+  })
+}
+
+export async function listLinearIssuesViaComposio(params: {
+  entityId: string
+  connectedAccountId: string
+  projectId?: string
+  teamId?: string
+}) {
+  if (params.projectId) {
+    try {
+      return await runLinearTool({
+        entityId: params.entityId,
+        connectedAccountId: params.connectedAccountId,
+        toolSlug: "LINEAR_LIST_LINEAR_ISSUES",
+        arguments: { project_id: params.projectId },
+      })
+    } catch (error) {
+      console.warn(
+        "[linear] LINEAR_LIST_LINEAR_ISSUES by project failed, trying team list:",
+        error,
+      )
+    }
+  }
+
+  if (params.teamId) {
+    return runLinearTool({
+      entityId: params.entityId,
+      connectedAccountId: params.connectedAccountId,
+      toolSlug: "LINEAR_LIST_ISSUES_BY_TEAM_ID",
+      arguments: { team_id: params.teamId },
+    })
+  }
+
+  return runLinearTool({
+    entityId: params.entityId,
+    connectedAccountId: params.connectedAccountId,
+    toolSlug: "LINEAR_LIST_LINEAR_ISSUES",
+    arguments: {},
+  })
+}
+
+export async function updateLinearIssueViaComposio(params: {
+  entityId: string
+  connectedAccountId: string
+  issueId: string
+  title?: string
+  description?: string
+  projectId?: string
+}) {
+  return runLinearTool({
+    entityId: params.entityId,
+    connectedAccountId: params.connectedAccountId,
+    toolSlug: "LINEAR_UPDATE_ISSUE",
+    arguments: {
+      issue_id: params.issueId,
+      ...(params.title ? { title: params.title } : {}),
+      ...(params.description ? { description: params.description } : {}),
+      ...(params.projectId ? { project_id: params.projectId } : {}),
+    },
+  })
+}
+
+function buildIssueTitle(params: {
+  owner: string
+  repo: string
+  prNumber: number
+  prTitle: string
+}) {
+  const title = params.prTitle?.trim() || `PR #${params.prNumber}`
+  return `${params.owner}/${params.repo}#${params.prNumber}: ${title}`.slice(0, 240)
+}
+
+function buildIssueDescription(params: {
+  owner: string
+  repo: string
+  prNumber: number
+  prTitle: string
+  prUrl: string
+  prDescription: string
+  reviewMarkdown: string
+}) {
+  const prDescription =
+    params.prDescription?.trim() || "_No pull request description provided._"
+  const review = params.reviewMarkdown?.trim() || "_Review body empty._"
+
+  const body = [
+    `## ${params.prTitle || `PR #${params.prNumber}`}`,
+    ``,
+    `**Pull request:** [${params.owner}/${params.repo}#${params.prNumber}](${params.prUrl})`,
+    ``,
+    `### PR description`,
+    prDescription,
+    ``,
+    `---`,
+    ``,
+    `### Supercode review`,
+    review,
+  ].join("\n")
+
+  return truncate(body, MAX_LINEAR_DESCRIPTION_CHARS)
+}
+
+async function resolveTeamId(params: {
+  entityId: string
+  connectedAccountId: string
+  preferredTeamId?: string | null
+  preferredTeamName?: string | null
+}): Promise<{ teamId: string; teamName: string | null }> {
+  if (params.preferredTeamId) {
+    return {
+      teamId: params.preferredTeamId,
+      teamName: params.preferredTeamName ?? null,
+    }
+  }
+
+  const listed = await listLinearTeamsViaComposio({
+    entityId: params.entityId,
+    connectedAccountId: params.connectedAccountId,
+  })
+  const teams = extractTeams(listed)
+  if (teams.length === 0) {
+    throw new Error("No Linear teams found for connected account")
+  }
+
+  if (params.preferredTeamName) {
+    const match = teams.find(
+      (t) =>
+        t.name?.toLowerCase() === params.preferredTeamName!.toLowerCase(),
+    )
+    if (match) return { teamId: match.id, teamName: match.name }
+  }
+
+  return { teamId: teams[0].id, teamName: teams[0].name }
+}
+
+async function listAllLinearProjects(params: {
+  entityId: string
+  connectedAccountId: string
+}): Promise<Array<{ id: string; name: string | null }>> {
+  const listed = await listLinearProjectsViaComposio({
+    entityId: params.entityId,
+    connectedAccountId: params.connectedAccountId,
+  })
+  return extractProjects(listed)
+}
+
+/**
+ * Resolve the single shared Linear project for reviews.
+ * Order: cached id → existing name match (supercodeAI variants) → create once.
+ * Never creates when a match or cache already exists.
+ */
+async function ensureSupercodeAiProject(params: {
+  entityId: string
+  connectedAccountId: string
+  teamId: string
+  cachedProjectId?: string | null
+}): Promise<string> {
+  // Fast path: once we've stored the project id, always reuse it.
+  // Avoids list/create races that would spawn duplicate projects per review.
+  if (params.cachedProjectId?.trim()) {
+    return params.cachedProjectId.trim()
+  }
+
+  let projects: Array<{ id: string; name: string | null }> = []
+  try {
+    projects = await listAllLinearProjects({
+      entityId: params.entityId,
+      connectedAccountId: params.connectedAccountId,
+    })
+    const existing = projects.find((p) => isSupercodeAiProjectName(p.name))
+    if (existing?.id) {
+      console.log(
+        `[linear] reusing existing project "${existing.name}" id=${existing.id}`,
+      )
+      return existing.id
+    }
+  } catch (error) {
+    console.warn("[linear] list projects failed before create:", error)
+  }
+
+  console.log(
+    `[linear] creating project "${SUPERCODE_AI_PROJECT_NAME}" on team=${params.teamId}`,
+  )
+  try {
+    const created = await createLinearProjectViaComposio({
+      entityId: params.entityId,
+      connectedAccountId: params.connectedAccountId,
+      name: SUPERCODE_AI_PROJECT_NAME,
+      teamIds: [params.teamId],
+      description:
+        "Automated PR reviews from Supercode Review. One shared project for all connected-repo reviews — issues are created/updated per PR, not new projects.",
+    })
+
+    const projectId = extractId(created, ["id", "projectId", "project_id"])
+    if (projectId) return projectId
+  } catch (createError) {
+    // Another worker may have created it concurrently — re-list and reuse.
+    console.warn(
+      "[linear] create project failed; re-listing for existing supercodeAI:",
+      createError,
+    )
+  }
+
+  try {
+    projects = await listAllLinearProjects({
+      entityId: params.entityId,
+      connectedAccountId: params.connectedAccountId,
+    })
+    const existing = projects.find((p) => isSupercodeAiProjectName(p.name))
+    if (existing?.id) return existing.id
+  } catch (error) {
+    console.warn("[linear] re-list projects after create failed:", error)
+  }
+
+  throw new Error(
+    `Could not find or create Linear project "${SUPERCODE_AI_PROJECT_NAME}"`,
+  )
+}
+
+async function findExistingReviewIssue(params: {
+  entityId: string
+  connectedAccountId: string
+  projectId: string
+  teamId: string
+  prUrl: string
+  owner: string
+  repo: string
+  prNumber: number
+}): Promise<{ id: string; identifier: string | null; url: string | null } | null> {
+  const needleUrl = params.prUrl.toLowerCase()
+  const needleRef = `${params.owner}/${params.repo}#${params.prNumber}`.toLowerCase()
+  const needleTitlePrefix = `${params.owner}/${params.repo}#${params.prNumber}:`.toLowerCase()
+
+  try {
+    const listed = await listLinearIssuesViaComposio({
+      entityId: params.entityId,
+      connectedAccountId: params.connectedAccountId,
+      projectId: params.projectId,
+      teamId: params.teamId,
+    })
+    const issues = extractIssues(listed)
+    const match = issues.find((issue) => {
+      const title = (issue.title || "").toLowerCase()
+      const description = (issue.description || "").toLowerCase()
+      return (
+        title.startsWith(needleTitlePrefix) ||
+        description.includes(needleUrl) ||
+        description.includes(needleRef)
+      )
+    })
+    if (match) {
+      return { id: match.id, identifier: match.identifier, url: match.url }
+    }
+  } catch (error) {
+    console.warn("[linear] findExistingReviewIssue failed:", error)
+  }
+  return null
+}
+
+export type NotifyLinearReviewInput = {
+  userId: string
+  owner: string
+  repo: string
+  prNumber: number
+  prTitle: string
+  prUrl: string
+  prDescription: string
+  reviewMarkdown: string
+  reviewId?: string | null
+}
+
+export type NotifyLinearReviewResult = {
+  skipped?: boolean
+  reason?: string
+  issueId?: string
+  issueIdentifier?: string | null
+  issueUrl?: string | null
+  projectId?: string
+  teamId?: string
+  updated?: boolean
+}
+
+/**
+ * After a Supercode PR review completes, ensure Linear has a single "supercodeAI"
+ * project and create/update an issue for this PR under that project (never a new project per review).
+ */
+export async function notifyLinearOfCompletedReview(
+  input: NotifyLinearReviewInput,
+): Promise<NotifyLinearReviewResult> {
+  if (!isComposioConfigured()) {
+    return { skipped: true, reason: "composio_not_configured" }
+  }
+
+  const organizationId = await getOrganizationIdForUser(input.userId)
+  if (!organizationId) {
+    return { skipped: true, reason: "no_organization" }
+  }
+
+  const integration = await prisma.integration.findUnique({
+    where: {
+      organizationId_provider: {
+        organizationId,
+        provider: "linear",
+      },
+    },
+  })
+
+  if (!integration?.isActive || !integration.composioConnectedAccountId) {
+    return { skipped: true, reason: "linear_not_connected" }
+  }
+
+  const entityId =
+    integration.composioEntityId || composioEntityIdForOrg(organizationId)
+  const connectedAccountId = integration.composioConnectedAccountId
+  const cached = readLinearConfig(integration.config)
+
+  const { teamId, teamName } = await resolveTeamId({
+    entityId,
+    connectedAccountId,
+    preferredTeamId: cached.supercodeAiTeamId || integration.linearTeamId,
+    preferredTeamName: integration.linearTeamName,
+  })
+
+  const projectId = await ensureSupercodeAiProject({
+    entityId,
+    connectedAccountId,
+    teamId,
+    cachedProjectId: cached.supercodeAiProjectId,
+  })
+
+  const nextConfig: LinearConfig = {
+    ...cached,
+    supercodeAiProjectId: projectId,
+    supercodeAiTeamId: teamId,
+  }
+  await prisma.integration.update({
+    where: { id: integration.id },
+    data: {
+      config: nextConfig,
+      ...(integration.linearTeamId
+        ? {}
+        : {
+            linearTeamId: teamId,
+            linearTeamName: teamName,
+          }),
+    },
+  })
+
+  const title = buildIssueTitle({
+    owner: input.owner,
+    repo: input.repo,
+    prNumber: input.prNumber,
+    prTitle: input.prTitle,
+  })
+  const description = buildIssueDescription({
+    owner: input.owner,
+    repo: input.repo,
+    prNumber: input.prNumber,
+    prTitle: input.prTitle,
+    prUrl: input.prUrl,
+    prDescription: input.prDescription,
+    reviewMarkdown: input.reviewMarkdown,
+  })
+
+  // Prefer our Conversation mapping (stable across re-reviews)
+  let existing: {
+    id: string
+    identifier: string | null
+    url: string | null
+  } | null = null
+
+  if (input.reviewId) {
+    try {
+      const mapped = await prisma.conversation.findFirst({
+        where: {
+          organizationId,
+          provider: "linear",
+          reviewId: input.reviewId,
+        },
+        orderBy: { updatedAt: "desc" },
+        select: { externalId: true },
+      })
+      if (mapped?.externalId) {
+        existing = {
+          id: mapped.externalId,
+          identifier: null,
+          url: null,
+        }
+      }
+    } catch (error) {
+      console.warn("[linear] conversation lookup by reviewId failed:", error)
+    }
+  }
+
+  if (!existing) {
+    existing = await findExistingReviewIssue({
+      entityId,
+      connectedAccountId,
+      projectId,
+      teamId,
+      prUrl: input.prUrl,
+      owner: input.owner,
+      repo: input.repo,
+      prNumber: input.prNumber,
+    })
+  }
+
+  let issueId: string
+  let issueIdentifier: string | null = null
+  let issueUrl: string | null = null
+  let updated = false
+
+  if (existing) {
+    await updateLinearIssueViaComposio({
+      entityId,
+      connectedAccountId,
+      issueId: existing.id,
+      title,
+      description,
+      projectId,
+    })
+    issueId = existing.id
+    issueIdentifier = existing.identifier
+    issueUrl = existing.url
+    updated = true
+  } else {
+    const created = await createLinearIssueViaComposio({
+      entityId,
+      connectedAccountId,
+      title,
+      description,
+      teamId,
+      projectId,
+    })
+    const createdIssue = extractIssues(created)[0]
+    issueId =
+      createdIssue?.id ||
+      extractId(created, ["id", "issueId", "issue_id"]) ||
+      ""
+    if (!issueId) {
+      throw new Error("LINEAR_CREATE_LINEAR_ISSUE returned no issue id")
+    }
+    issueIdentifier = createdIssue?.identifier ?? null
+    issueUrl = createdIssue?.url ?? null
+  }
+
+  try {
+    await prisma.conversation.upsert({
+      where: {
+        organizationId_provider_externalId: {
+          organizationId,
+          provider: "linear",
+          externalId: issueId,
+        },
+      },
+      create: {
+        organizationId,
+        provider: "linear",
+        externalId: issueId,
+        reviewId: input.reviewId ?? null,
+        channelId: projectId,
+        messages: {
+          create: {
+            role: "system",
+            content: updated
+              ? `Updated Linear issue for ${input.owner}/${input.repo}#${input.prNumber}`
+              : `Created Linear issue for ${input.owner}/${input.repo}#${input.prNumber}`,
+            metadata: {
+              issueIdentifier,
+              issueUrl,
+              projectId,
+              teamId,
+              prUrl: input.prUrl,
+            },
+          },
+        },
+      },
+      update: {
+        reviewId: input.reviewId ?? undefined,
+        channelId: projectId,
+        messages: {
+          create: {
+            role: "system",
+            content: `Synced Supercode review to Linear for ${input.owner}/${input.repo}#${input.prNumber}`,
+            metadata: {
+              issueIdentifier,
+              issueUrl,
+              projectId,
+              teamId,
+              prUrl: input.prUrl,
+              updated,
+            },
+          },
+        },
+      },
+    })
+  } catch (error) {
+    console.warn("[linear] conversation upsert failed (non-fatal):", error)
+  }
+
+  return {
+    issueId,
+    issueIdentifier,
+    issueUrl,
+    projectId,
+    teamId,
+    updated,
+  }
 }

--- a/apps/web/modules/integrations/lib/linear.ts
+++ b/apps/web/modules/integrations/lib/linear.ts
@@ -231,6 +231,15 @@ export async function listLinearTeamsViaComposio(params: {
   })
 }
 
+/** Parsed team list for UI / workspace picker. */
+export async function getLinearTeamsForConnectedAccount(params: {
+  entityId: string
+  connectedAccountId: string
+}): Promise<Array<{ id: string; name: string | null }>> {
+  const listed = await listLinearTeamsViaComposio(params)
+  return extractTeams(listed)
+}
+
 export async function listLinearProjectsViaComposio(params: {
   entityId: string
   connectedAccountId: string
@@ -567,7 +576,7 @@ export async function notifyLinearOfCompletedReview(
     },
   })
 
-  if (!integration?.isActive || !integration.composioConnectedAccountId) {
+if (!integration?.isActive || !integration.composioConnectedAccountId) {
     return { skipped: true, reason: "linear_not_connected" }
   }
 
@@ -576,10 +585,18 @@ export async function notifyLinearOfCompletedReview(
   const connectedAccountId = integration.composioConnectedAccountId
   const cached = readLinearConfig(integration.config)
 
+  // Require an explicitly chosen workspace so we never create supercodeAI
+  // under a random first team from LINEAR_GET_ALL_LINEAR_TEAMS.
+  const preferredTeamId =
+    integration.linearTeamId || cached.supercodeAiTeamId || null
+  if (!preferredTeamId) {
+    return { skipped: true, reason: "linear_team_not_selected" }
+  }
+
   const { teamId, teamName } = await resolveTeamId({
     entityId,
     connectedAccountId,
-    preferredTeamId: cached.supercodeAiTeamId || integration.linearTeamId,
+    preferredTeamId,
     preferredTeamName: integration.linearTeamName,
   })
 


### PR DESCRIPTION


## Description

- Updated generateReview and runGeneratePrReview functions to include Linear notification handling.
- Added new properties to GeneratePrReviewResult for tracking Linear notification status and issue details.
- Implemented error handling for Linear notifications to ensure robustness in review processing.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes (if applicable)

## Checklist:

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed AI reviews can be shared automatically with connected Linear workspaces.
  * Choose or change the Linear workspace used for review notifications.
  * Reviews are organized in a shared project and linked to the relevant pull request issue.
  * Existing Linear issues are updated when available; otherwise, a new issue is created.
  * Review processing reports whether Linear notification succeeded, was skipped, or could not be completed.

* **Improvements**
  * Improved reliability and configuration of Linear integration actions.
  * Linear notifications now handle missing workspace selections gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->